### PR TITLE
Alembic config

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,7 +1,6 @@
 from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
 
 from delivery.models.db_models import SQLAlchemyBase
 
@@ -9,9 +8,6 @@ from delivery.models.db_models import SQLAlchemyBase
 # access to the values within the .ini file in use.
 config = context.config
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/config/alembic.ini
+++ b/config/alembic.ini
@@ -53,7 +53,7 @@ handlers =
 qualname = sqlalchemy.engine
 
 [logger_alembic]
-level = INFO
+level = DEBUG
 handlers =
 qualname = alembic
 

--- a/config/alembic.ini
+++ b/config/alembic.ini
@@ -32,36 +32,3 @@ script_location = alembic
 sqlalchemy.url = sqlite:///my.db
 
 
-# Logging configuration
-[loggers]
-keys = root,sqlalchemy,alembic
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = WARN
-handlers = console
-qualname =
-
-[logger_sqlalchemy]
-level = WARN
-handlers =
-qualname = sqlalchemy.engine
-
-[logger_alembic]
-level = DEBUG
-handlers =
-qualname = alembic
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format =  %(asctime)s - %(name)s - %(levelname)s - %(message)s


### PR DESCRIPTION
When Alembic was allowed to configure the logging it interfered with the rest of the applications logging. Now we don't load Alembics logging config from `env.py` and everything seems to be working.