### PR TITLE
Mover as backend

### DIFF
--- a/alembic/versions/7ef1e44e41b7_first_auto_generation_of_db_from_models.py
+++ b/alembic/versions/7ef1e44e41b7_first_auto_generation_of_db_from_models.py
@@ -22,7 +22,7 @@ def upgrade():
     sa.Column('delivery_source', sa.String(), nullable=False),
     sa.Column('delivery_project', sa.String(), nullable=False),
     sa.Column('delivery_status', sa.Enum('mover_processing_delivery', 'delivery_failed', 'delivery_in_progress',
-                                         'delivery_successful', 'pending', 'mover_failed_delivery', name='deliverystatus'), nullable=True),
+                                         'delivery_successful', 'pending', 'mover_failed_delivery', 'delivery_skipped', name='deliverystatus'), nullable=True),
     sa.PrimaryKeyConstraint('id')
     )
     op.create_table('staging_orders',

--- a/delivery/exceptions.py
+++ b/delivery/exceptions.py
@@ -27,3 +27,9 @@ class InvalidStatusException(Exception):
     on a StagingOrder which is already `in_progress`
     """
     pass
+
+class CannotParseMoverOutputException(Exception):
+    """
+    Should be raised when movers output cannot be parsed for e.g. a mover delivery id.
+    """
+    pass

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -75,6 +75,7 @@ class DeliveryStatus(base_enum.Enum):
     delivery_in_progress = 'delivery_in_progress'
     delivery_successful = 'delivery_successful'
     delivery_failed = 'delivery_failed'
+    delivery_skipped = 'delivery_skipped'
 
 
 class DeliveryOrder(SQLAlchemyBase):

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -111,7 +111,8 @@ class MoverDeliveryService(object):
         if hits:
             return hits.group(1)
         else:
-            raise CannotParseMoverOutputException("Could not parse mover id from: {}".format(mover_info_result))
+            raise CannotParseMoverOutputException("Could not parse mover info status from: {}".
+                                                  format(mover_info_result))
 
     def _run_mover_info(self, mover_delivery_order_id):
 

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -1,8 +1,6 @@
 
 
 import json
-import os
-from mock import MagicMock
 from functools import partial
 
 
@@ -36,9 +34,6 @@ class TestIntegration(AsyncHTTPTestCase):
 
         # Get an as similar app as possible, tough note that we don't use the
         #  app service start method to start up the the application
-        # TODO
-        # Also not that that we need to mock away the delivery service, since Mover is
-        # not expected to be installed on the developers system.
         path_to_this_file = os.path.abspath(
             os.path.dirname(os.path.realpath(__file__)))
         app_svc = AppService.create(product_name="test_delivery_service",
@@ -73,6 +68,9 @@ class TestIntegration(AsyncHTTPTestCase):
         self.assertEqual(first_project["name"], "ABC_123")
 
     def test_can_stage_and_delivery_runfolder(self):
+        # Note that this is a test which skips mover (since to_outbox is not expected to be installed on the system
+        # where this runs)
+
         url = "/".join([self.API_BASE, "stage", "runfolder", "160930_ST-E00216_0111_BH37CWALXX"])
         response = self.fetch(url, method='POST', body='')
         self.assertEqual(response.code, 202)
@@ -102,7 +100,8 @@ class TestIntegration(AsyncHTTPTestCase):
 
         for project, staging_id in staging_order_project_and_id.iteritems():
             delivery_url = '/'.join([self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
-            delivery_body = {'delivery_project_id': 'fakedeliveryid2016'}
+            delivery_body = {'delivery_project_id': 'fakedeliveryid2016',
+                             'skip_mover': True}
             delivery_resp = self.fetch(delivery_url, method='POST', body=json.dumps(delivery_body))
             delivery_resp_as_json = json.loads(delivery_resp.body)
             delivery_link = delivery_resp_as_json['delivery_order_link']
@@ -111,9 +110,12 @@ class TestIntegration(AsyncHTTPTestCase):
                                      timeout=5,
                                      delay=1,
                                      f=partial(self._get_delivery_status, delivery_link),
-                                     expected=DeliveryStatus.delivery_successful.name)
+                                     expected=DeliveryStatus.delivery_skipped.name)
 
     def test_can_stage_and_delivery_project_dir(self):
+        # Note that this is a test which skips mover (since to_outbox is not expected to be installed on the system
+        # where this runs)
+
         url = "/".join([self.API_BASE, "stage", "project", "my_test_project"])
         response = self.fetch(url, method='POST', body='')
         self.assertEqual(response.code, 202)
@@ -135,7 +137,8 @@ class TestIntegration(AsyncHTTPTestCase):
 
         for project, staging_id in staging_order_project_and_id.iteritems():
             delivery_url = '/'.join([self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
-            delivery_body = {'delivery_project_id': 'fakedeliveryid2016'}
+            delivery_body = {'delivery_project_id': 'fakedeliveryid2016',
+                             'skip_mover': True}
             delivery_resp = self.fetch(delivery_url, method='POST', body=json.dumps(delivery_body))
             delivery_resp_as_json = json.loads(delivery_resp.body)
             delivery_link = delivery_resp_as_json['delivery_order_link']
@@ -144,7 +147,7 @@ class TestIntegration(AsyncHTTPTestCase):
                                      timeout=5,
                                      delay=1,
                                      f=partial(self._get_delivery_status, delivery_link),
-                                     expected=DeliveryStatus.delivery_successful.name)
+                                     expected=DeliveryStatus.delivery_skipped.name)
 
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,29 +17,6 @@ class MockIOLoop():
     def spawn_callback(self, f, **args):
         f(**args)
 
-
-class MockExternalRunnerService():
-
-    def __init__(self, return_status=0, stdout="stdout", stderr="stderr", throw=False):
-        self.return_status = return_status
-        self.throw = throw
-        self.stdout = stdout
-        self.stderr = stderr
-
-    def run(self, cmd):
-        if self.throw:
-            raise Exception("Test the exception handling...")
-        mock_process = MagicMock()
-        execution = Execution(pid=random.randint(1, 1000), process_obj=mock_process)
-        return execution
-
-    def wait_for_execution(self, execution):
-        time.sleep(0.1)
-        return ExecutionResult(status_code=self.return_status,
-                               stderr=self.stderr,
-                               stdout=self.stdout)
-
-
 class TestUtils:
     DUMMY_CONFIG = {"monitored_directory": "/foo"}
 

--- a/tests/unit_tests/services/test_delivery_service.py
+++ b/tests/unit_tests/services/test_delivery_service.py
@@ -1,18 +1,38 @@
-import unittest
-from mock import MagicMock
 
+import random
+import unittest
+from mock import MagicMock, create_autospec
+
+from delivery.services.external_program_service import ExternalProgramService
 from delivery.services.delivery_service import MoverDeliveryService
 from delivery.models.db_models import DeliveryOrder, StagingOrder, StagingStatus, DeliveryStatus
-from delivery.exceptions import InvalidStatusException
+from delivery.models.execution import ExecutionResult, Execution
+from delivery.exceptions import InvalidStatusException, CannotParseMoverOutputException
 
-from tests.test_utils import MockIOLoop, MockExternalRunnerService, assert_eventually_equals
+from tests.test_utils import MockIOLoop, assert_eventually_equals
 
 
 class TestMoverDeliveryService(unittest.TestCase):
 
     def setUp(self):
 
-        self.mock_external_program_service = MockExternalRunnerService(return_status=0)
+        example_mover_stdout = """id=TestCase_31-ngi2016001-1484739218 Found receiver delivery00001 with end date: 2017-03-11
+                                  TestCase_31 queued for delivery to delivery00001, id = TestCase_31-ngi2016001-1484739218"""
+
+        example_moverinfo_stdout = """Delivered: Jan 19 00:23:31 [1484781811UTC]"""
+
+        mock_mover_runner = create_autospec(ExternalProgramService)
+        mock_process = MagicMock()
+        mock_execution = Execution(pid=random.randint(1, 1000), process_obj=mock_process)
+        mock_mover_runner.run.return_value = mock_execution
+        mock_mover_runner.wait_for_execution.return_value = ExecutionResult(stdout=example_mover_stdout,
+                                                                            stderr="",
+                                                                            status_code=0)
+
+        mock_moverinfo_runner = create_autospec(ExternalProgramService)
+        mock_moverinfo_runner.run_and_wait.return_value = ExecutionResult(stdout=example_moverinfo_stdout,
+                                                                          stderr="",
+                                                                          status_code=0)
         self.mock_staging_service = MagicMock()
         self.mock_delivery_repo = MagicMock()
 
@@ -22,14 +42,19 @@ class TestMoverDeliveryService(unittest.TestCase):
         self.mock_delivery_repo.get_delivery_order_by_id.return_value = self.delivery_order
 
         self.mock_session_factory = MagicMock()
-        self.mover_delivery_service = MoverDeliveryService(external_program_service=self.mock_external_program_service,
+        self.mover_delivery_service = MoverDeliveryService(external_program_service=None,
                                                            staging_service=self.mock_staging_service,
                                                            delivery_repo=self.mock_delivery_repo,
                                                            session_factory=self.mock_session_factory)
+
+        # Inject separate external runner instances for the tests, since they need to return
+        # different information
+        self.mover_delivery_service.mover_external_program_service = mock_mover_runner
+        self.mover_delivery_service.moverinfo_external_program_service = mock_moverinfo_runner
+
         self.mover_delivery_service.io_loop_factory = MockIOLoop
 
     def test_deliver_by_staging_id(self):
-
         staging_order = StagingOrder(source='/foo/bar', staging_target='/staging/dir/bar')
         staging_order.status = StagingStatus.staging_successful
         self.mock_staging_service.get_stage_order_by_id.return_value = staging_order
@@ -43,7 +68,13 @@ class TestMoverDeliveryService(unittest.TestCase):
         def _get_delivery_order():
             return self.delivery_order.delivery_status
         assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_in_progress)
-        # TODO Finish checking this up!
+
+    def test_update_delivery_status(self):
+        delivery_order = DeliveryOrder(mover_delivery_id="TestCase_31-ngi2016001-1484739218 ",
+                                       delivery_status=DeliveryStatus.delivery_in_progress)
+        self.mock_delivery_repo.get_delivery_order_by_id.return_value = delivery_order
+        result = self.mover_delivery_service.update_delivery_status(self.delivery_order.id)
+        self.assertEqual(result.delivery_status, DeliveryStatus.delivery_successful)
 
     def test_deliver_by_staging_id_raises_on_non_existent_stage_id(self):
         self.mock_staging_service.get_stage_order_by_id.return_value = None
@@ -87,3 +118,42 @@ class TestMoverDeliveryService(unittest.TestCase):
         self.mock_delivery_repo.get_delivery_order_by_id.return_value = delivery_order
         actual = self.mover_delivery_service.get_delivery_order_by_id(1)
         self.assertEqual(actual.id, 1)
+
+    def test_possible_to_delivery_by_staging_id_and_skip_mover(self):
+
+        staging_order = StagingOrder(source='/foo/bar', staging_target='/staging/dir/bar')
+        staging_order.status = StagingStatus.staging_successful
+        self.mock_staging_service.get_stage_order_by_id.return_value = staging_order
+
+        self.mock_staging_service.get_delivery_order_by_id.return_value = self.delivery_order
+
+        self.mover_delivery_service.deliver_by_staging_id(staging_id=1,
+                                                          delivery_project='xyz123',
+                                                          md5sum_file='md5sum_file',
+                                                          skip_mover=True)
+
+        def _get_delivery_order():
+            return self.delivery_order.delivery_status
+        assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_skipped)
+
+    def test__parse_mover_id_from_mover_output(self):
+        example_mover_output = """id=TestCase_31-ngi2016001-1484739218 Found receiver delivery00001 with end date: 2017-03-11
+                                  TestCase_31 queued for delivery to delivery00001, id = TestCase_31-ngi2016001-1484739218"""
+
+        actual = self.mover_delivery_service._parse_mover_id_from_mover_output(example_mover_output)
+        self.assertEqual(actual, "TestCase_31-ngi2016001-1484739218")
+
+    def test__parse_mover_id_from_mover_output_raises_on_invalid_output(self):
+        example_mover_output = """Found receiver delivery00001 with end date: 2017-03-11
+                                  TestCase_31 queued for delivery to delivery00001, id = TestCase_31-ngi2016001-1484739218"""
+        with self.assertRaises(CannotParseMoverOutputException):
+            self.mover_delivery_service._parse_mover_id_from_mover_output(example_mover_output)
+
+    def test__parse_status_from_mover_info_result(self):
+        example_moverinfo_stdout = """Delivered: Jan 19 00:23:31 [1484781811UTC]"""
+        actual = self.mover_delivery_service._parse_status_from_mover_info_result(example_moverinfo_stdout)
+        self.assertEqual(actual, "Delivered")
+
+    def test__parse_status_from_mover_info_result_raises_on_invalid_output(self):
+        with self.assertRaises(CannotParseMoverOutputException):
+            self.mover_delivery_service._parse_status_from_mover_info_result("Invalid input...")


### PR DESCRIPTION
A semi-large PR this time...

This introduces mover as the actual backend for the delivery service. It also introduces the possibility of skipping running mover (so that we can run integration tests without making real deliveries). 

Have a look and let me know what you think.