### PR TITLE
Fixing bugs found in integration testing

### DIFF
--- a/delivery/app.py
+++ b/delivery/app.py
@@ -56,8 +56,6 @@ def routes(**kwargs):
         url(r"/api/1.0/deliver/status/(.+)", DeliveryStatusHandler,
             name="delivery_status", kwargs=kwargs),
 
-        #url(r"/api/1.0/test", AsyncHandler,
-        #    name="async", kwargs=kwargs),
     ]
 
 

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -24,8 +24,9 @@ class RunfolderProjectRepository(object):
         :return: a generator of project instances
         """
         for runfolder in self.runfolder_repository.get_runfolders():
-            for project in runfolder.projects:
-                yield project
+            if runfolder.projects:
+                for project in runfolder.projects:
+                    yield project
 
 
 class GeneralProjectRepository(object):

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -25,6 +25,12 @@ class FileSystemBasedRunfolderRepository(object):
         self.file_system_service = file_system_service
 
     def _add_projects_to_runfolder(self, runfolder):
+        """
+        Will take the given runfolder and mutate the `projects` field.
+        If there are no projects found it will leave `projects` as None.
+        :param runfolder: to add projects to
+        :return: None
+        """
         try:
             projects_base_dir = os.path.join(runfolder.path, "Projects")
             project_directories = self.file_system_service.find_project_directories(
@@ -44,8 +50,6 @@ class FileSystemBasedRunfolderRepository(object):
         except FileNotFoundError as e:
             log.warning("Did not find Project folder for: {}".format(runfolder.name))
             pass
-        finally:
-            return runfolder
 
     def _get_runfolders(self):
         # TODO Filter based on expression for runfolders...

--- a/delivery/services/staging_service.py
+++ b/delivery/services/staging_service.py
@@ -78,7 +78,7 @@ class StagingService(object):
         staging_order = staging_repo.get_staging_order_by_id(staging_order_id, session)
         try:
 
-            cmd = ['rsync', '--stats', '-r', staging_order.source, staging_order.staging_target]
+            cmd = ['rsync', '--stats', '-r', '--copy-links', staging_order.source, staging_order.staging_target]
 
             execution = external_program_service.run(cmd)
 

--- a/requirements/prod
+++ b/requirements/prod
@@ -4,5 +4,4 @@ sqlalchemy==1.1.3
 alembic==0.8.8
 enum34==1.1.6
 git+https://github.com/arteria-project/arteria-core.git@v1.0.1#egg=arteria-core
-git+https://github.com/dakl/localq.git@v0.3.7
 

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -55,6 +55,9 @@ class TestIntegration(AsyncHTTPTestCase):
         self.assertEqual(len(response_json), 1)
 
         first_runfolder = response_json["runfolders"][0]
+        self.assertEqual(first_runfolder["name"], "160930_ST-E00216_0112_AH37CWALXX")
+
+        first_runfolder = response_json["runfolders"][1]
         self.assertEqual(first_runfolder["name"], "160930_ST-E00216_0111_BH37CWALXX")
 
     def test_can_return_projects(self):

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -54,11 +54,13 @@ class TestIntegration(AsyncHTTPTestCase):
         response_json = json.loads(response.body)
         self.assertEqual(len(response_json), 1)
 
-        first_runfolder = response_json["runfolders"][0]
-        self.assertEqual(first_runfolder["name"], "160930_ST-E00216_0112_AH37CWALXX")
+        runfolder_names = []
+        for runfolder_json in response_json["runfolders"]:
+            runfolder_names.append(runfolder_json["name"])
 
-        first_runfolder = response_json["runfolders"][1]
-        self.assertEqual(first_runfolder["name"], "160930_ST-E00216_0111_BH37CWALXX")
+        self.assertIn("160930_ST-E00216_0112_AH37CWALXX", runfolder_names)
+
+        self.assertIn("160930_ST-E00216_0111_BH37CWALXX", runfolder_names)
 
     def test_can_return_projects(self):
         response = self.fetch(self.API_BASE + "/projects")


### PR DESCRIPTION
This fixes two bugs found in the process of integration testing:

 - Rsync will copy links
 - If there is no `Project` dir in another runfolder it will not break the listing of other runfolders

