### PR TITLE
Path to mover is specified, moverinfo and to_outbox is now called with

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -7,4 +7,5 @@ alembic_path: 'alembic/'
 runfolder_directory: tests/resources/runfolders
 general_project_directory: tests/resources/projects
 staging_directory: /tmp/
+path_to_mover: '/usr/local/mover/1.0.0/'
 port: 9999

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -123,10 +123,12 @@ def compose_application(config):
 
     delivery_repo = DatabaseBasedDeliveriesRepository(session_factory=session_factory)
 
+    path_to_mover = config['path_to_mover']
     delivery_service = MoverDeliveryService(external_program_service=external_program_service,
                                             staging_service=staging_service,
                                             delivery_repo=delivery_repo,
-                                            session_factory=session_factory)
+                                            session_factory=session_factory,
+                                            path_to_mover=path_to_mover)
 
     return dict(config=config,
                 runfolder_repo=runfolder_repo,

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -1,3 +1,4 @@
+import os.path
 import logging
 import re
 from tornado import gen
@@ -40,7 +41,7 @@ class MoverDeliveryService(object):
         delivery_order = delivery_order_repo.get_delivery_order_by_id(delivery_order_id, session)
         try:
 
-            cmd = [path_to_mover+'/to_outbox',
+            cmd = [os.path.join(path_to_mover, 'to_outbox'),
                    delivery_order.delivery_source,
                    delivery_order.delivery_project]
 
@@ -117,7 +118,7 @@ class MoverDeliveryService(object):
     @gen.coroutine
     def _run_mover_info(self, mover_delivery_order_id):
 
-        cmd = [self.path_to_mover+'/moverinfo', '-i', mover_delivery_order_id]
+        cmd = [os.path.join(self.path_to_mover, 'moverinfo'), '-i', mover_delivery_order_id]
         execution_result = yield self.moverinfo_external_program_service.run_and_wait(cmd)
 
         if execution_result.status_code == 0:

--- a/tests/unit_tests/services/test_delivery_service.py
+++ b/tests/unit_tests/services/test_delivery_service.py
@@ -80,7 +80,7 @@ class TestMoverDeliveryService(AsyncTestCase):
         def _get_delivery_order():
             return self.delivery_order.delivery_status
         assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_in_progress)
-        self.mock_mover_runner.run.assert_called_once_with(['/foo/bar//to_outbox', '/foo', 'TestProj'])
+        self.mock_mover_runner.run.assert_called_once_with(['/foo/bar/to_outbox', '/foo', 'TestProj'])
 
     @gen_test
     def test_update_delivery_status(self):
@@ -90,7 +90,7 @@ class TestMoverDeliveryService(AsyncTestCase):
         result = yield self.mover_delivery_service.update_delivery_status(self.delivery_order.id)
         self.assertEqual(result.delivery_status, DeliveryStatus.delivery_successful)
 
-        self.mock_moverinfo_runner.run_and_wait.assert_called_once_with(['/foo/bar//moverinfo', '-i', 'TestCase_31-ngi2016001-1484739218 '])
+        self.mock_moverinfo_runner.run_and_wait.assert_called_once_with(['/foo/bar/moverinfo', '-i', 'TestCase_31-ngi2016001-1484739218 '])
 
     @gen_test
     def test_deliver_by_staging_id_raises_on_non_existent_stage_id(self):


### PR DESCRIPTION
full path. Before mover was loaded via the module system.