### PR TITLE
parsing mover/1.0.0 output

### DIFF
--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -23,7 +23,7 @@ class MoverDeliveryService(object):
     @staticmethod
     def _parse_mover_id_from_mover_output(mover_output):
         log.debug('Mover output was: {}'.format(mover_output))
-        pattern = re.compile('^id=(.+-\w+-\d+)\sFound')
+        pattern = re.compile('^(.+-\w+-\d+)$')
         hits = pattern.match(mover_output)
         if hits:
             return hits.group(1)

--- a/tests/unit_tests/services/test_delivery_service.py
+++ b/tests/unit_tests/services/test_delivery_service.py
@@ -18,8 +18,7 @@ class TestMoverDeliveryService(AsyncTestCase):
 
     def setUp(self):
 
-        example_mover_stdout = """id=TestCase_31-ngi2016001-1484739218 Found receiver delivery00001 with end date: 2017-03-11
-                                  TestCase_31 queued for delivery to delivery00001, id = TestCase_31-ngi2016001-1484739218"""
+        example_mover_stdout = """TestCase_31-ngi2016001-1484739218"""
 
         example_moverinfo_stdout = """Delivered: Jan 19 00:23:31 [1484781811UTC]"""
 
@@ -155,15 +154,13 @@ class TestMoverDeliveryService(AsyncTestCase):
         assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_skipped)
 
     def test__parse_mover_id_from_mover_output(self):
-        example_mover_output = """id=TestCase_31-ngi2016001-1484739218 Found receiver delivery00001 with end date: 2017-03-11
-                                  TestCase_31 queued for delivery to delivery00001, id = TestCase_31-ngi2016001-1484739218"""
+        example_mover_output = """TestCase_31-ngi2016001-1484739218"""
 
         actual = self.mover_delivery_service._parse_mover_id_from_mover_output(example_mover_output)
         self.assertEqual(actual, "TestCase_31-ngi2016001-1484739218")
 
     def test__parse_mover_id_from_mover_output_with_dash(self):
-        example_mover_output = """id=TestCase-31-ngi2016001-1484739218 Found receiver delivery00001 with end date: 2017-03-11
-                                  TestCase-31 queued for delivery to delivery00001, id = TestCase-31-ngi2016001-1484739218"""
+        example_mover_output = """TestCase-31-ngi2016001-1484739218"""
 
         actual = self.mover_delivery_service._parse_mover_id_from_mover_output(example_mover_output)
         self.assertEqual(actual, "TestCase-31-ngi2016001-1484739218")


### PR DESCRIPTION
- Updated regexp to parse the Mover/1.0.0 output (i.e. no "id="-prefix)
- Updated tests to reflect output format change