### PR TITLE
Ensure project name is in staging target

### DIFF
--- a/delivery/repositories/staging_repository.py
+++ b/delivery/repositories/staging_repository.py
@@ -56,12 +56,14 @@ class DatabaseBasedStagingRepository(object):
         except NoResultFound:
             return None
 
-    def create_staging_order(self, source, status, staging_target_dir):
+    def create_staging_order(self, source, status, staging_target_dir, project_name):
         """
         Create a StatingOrder and commit it to the database
         :param source: the directory or file to stage
         :param status: the initial StatingStatus to assign to the StatingORder
         :param staging_target_dir: the directory to which the StagingOrder should transfer the source
+        :param project_name: name of the project to stage (this will be used to determine the name of the
+        staging target)
         :return:
         """
 
@@ -72,18 +74,13 @@ class DatabaseBasedStagingRepository(object):
 
         if self.file_system_service.isfile(order.source):
             log.debug("Order source is a file")
-            source_base_name = self.file_system_service.basename(order.source)
         elif self.file_system_service.isdir(order.source):
             log.debug("Order source is a dir")
-            source_base_name = self.file_system_service.basename(self.file_system_service.abspath(order.source))
         else:
             raise NotImplementedError("Could not parse a valid type from: {}, valid types"
                                       " are directory and file.".format(order.source))
 
-        staging_target = os.path.join(staging_target_dir,
-                                      "{}_{}".format(
-                                          order.id,
-                                          source_base_name))
+        staging_target = os.path.join(staging_target_dir, str(order.id), project_name)
 
         log.debug("Set the staging target to: {}".format(staging_target))
 

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -42,10 +42,10 @@ class DeliveryService(object):
         else:
             self.delivery_sources_repo.add_source(source)
 
-    def _validate_and_stage_source(self, source, force_delivery, path):
+    def _validate_and_stage_source(self, source, force_delivery, path, project_name):
         self._validate_source_and_add_to_repo(source, force_delivery, path)
         # Start staging
-        stage_order = self.staging_service.create_new_stage_order(path=source.path)
+        stage_order = self.staging_service.create_new_stage_order(path=source.path, project_name=project_name)
         self.staging_service.stage_order(stage_order)
         return stage_order
 
@@ -56,7 +56,7 @@ class DeliveryService(object):
                                                               source_name="{}/{}".format(project.runfolder_name,
                                                                                          project.name),
                                                               path=project.path)
-            stage_order = self._validate_and_stage_source(source, force_delivery, project.path)
+            stage_order = self._validate_and_stage_source(source, force_delivery, project.path, project.name)
             projects_and_stage_order_ids[project.name] = stage_order.id
 
         return projects_and_stage_order_ids
@@ -178,7 +178,7 @@ class DeliveryService(object):
                                                           batch_nbr=batch_nbr)
         self.delivery_sources_repo.add_source(source)
 
-        stage_order = self.staging_service.create_new_stage_order(path=source.path)
+        stage_order = self.staging_service.create_new_stage_order(path=source.path, project_name=project_name)
         self.staging_service.stage_order(stage_order)
         return {source.project_name: stage_order.id}
 
@@ -195,7 +195,7 @@ class DeliveryService(object):
                                                           source_name=os.path.basename(project.path),
                                                           path=project.path)
 
-        stage_order = self._validate_and_stage_source(source, force_delivery, project.path)
+        stage_order = self._validate_and_stage_source(source, force_delivery, project.path, project_name)
         return {source.project_name: stage_order.id}
 
     def check_staging_status(self, staging_id):

--- a/delivery/services/file_system_service.py
+++ b/delivery/services/file_system_service.py
@@ -104,3 +104,7 @@ class FileSystemService(object):
         :return: None
         """
         os.makedirs(path)
+
+    @staticmethod
+    def exists(path):
+        return os.path.exists(path)

--- a/delivery/services/mover_service.py
+++ b/delivery/services/mover_service.py
@@ -48,6 +48,8 @@ class MoverDeliveryService(object):
             if delivery_order.md5sum_file:
                 cmd += delivery_order.md5sum_file
 
+            log.debug("Running mover with cmd: {}".format(" ".join(cmd)))
+
             execution = external_program_service.run(cmd)
             delivery_order.delivery_status = DeliveryStatus.mover_processing_delivery
             delivery_order.mover_pid = execution.pid

--- a/tests/unit_tests/repositories/test_staging_repository.py
+++ b/tests/unit_tests/repositories/test_staging_repository.py
@@ -56,14 +56,15 @@ class TestStagingRepository(unittest.TestCase):
     def test_create_staging_order(self):
         order = self.staging_repo.create_staging_order(source='/foo',
                                                        status=StagingStatus.pending,
-                                                       staging_target_dir='/foo/target')
+                                                       staging_target_dir='/foo/target',
+                                                       project_name='bar')
 
         self.assertIsInstance(order, StagingOrder)
         self.assertEqual(order.status, StagingStatus.pending)
         self.assertEqual(order.id, 2)
         self.assertEqual(order.pid, None)
         self.assertEqual(order.source, '/foo')
-        self.assertEqual(order.staging_target, '/foo/target/2_foo')
+        self.assertEqual(order.staging_target, '/foo/target/2/bar')
 
         # Check that the object has been committed, i.e. there are no 'dirty' objects in session
         self.assertEqual(len(self.session.dirty), 0)

--- a/tests/unit_tests/services/test_staging_service.py
+++ b/tests/unit_tests/services/test_staging_service.py
@@ -10,6 +10,7 @@ import tornado.testing
 
 from delivery.exceptions import InvalidStatusException, RunfolderNotFoundException, ProjectNotFoundException
 from delivery.services.staging_service import StagingService
+from delivery.services.file_system_service import FileSystemService
 from delivery.services.external_program_service import ExternalProgramService
 from delivery.models.db_models import StagingOrder, StagingStatus
 from delivery.models.execution import Execution, ExecutionResult
@@ -70,6 +71,8 @@ class TestStagingService(AsyncTestCase):
         self.mock_external_runner_service = mock.create_autospec(ExternalProgramService)
         self.mock_external_runner_service.run.return_value = mock_execution
 
+        self.mock_file_system_service = mock.create_autospec(FileSystemService)
+
         @coroutine
         def wait_as_coroutine(x):
             return ExecutionResult(stdout=stdout_mimicing_rsync, stderr="", status_code=0)
@@ -83,14 +86,14 @@ class TestStagingService(AsyncTestCase):
 
         mock_db_session_factory = mock.MagicMock()
 
-
         self.staging_service = StagingService(staging_dir="/tmp",
                                               project_links_directory="/tmp",
                                               external_program_service=self.mock_external_runner_service,
                                               staging_repo=mock_staging_repo,
                                               runfolder_repo=self.mock_runfolder_repo,
                                               session_factory=mock_db_session_factory,
-                                              project_dir_repo=self.mock_general_project_repo)
+                                              project_dir_repo=self.mock_general_project_repo,
+                                              file_system_service=self.mock_file_system_service)
         self.staging_service.io_loop_factory = MockIOLoop
         super(TestStagingService, self).setUp()
 


### PR DESCRIPTION
This should make sure that the project name always ends up as part of the directory hierarchy when staging. This can then be picked up by mover. I've tested this as far as possible manually without actually running mover, and I think this should do the trick.