### PR TITLE
List staged data

### DIFF
--- a/delivery/handlers/staging_handlers.py
+++ b/delivery/handlers/staging_handlers.py
@@ -81,11 +81,14 @@ class StagingProjectRunfoldersHandler(BaseStagingHandler):
             delivery_mode = DeliveryMode[requested_delivery_mode]
             log.info("Will attempt to stage runfolders for project {} with type {}".format(project_id, delivery_mode))
 
-            project_and_stage_id = self.delivery_service.deliver_all_runfolders_for_project(project_id, delivery_mode)
+            project_and_stage_id, projects = self.delivery_service.deliver_all_runfolders_for_project(project_id, delivery_mode)
             links, staging_ids_ids = self._construct_response_from_project_and_status(project_and_stage_id)
+            project_and_staged_id_dict = list(map(lambda project: project.to_dict(), projects))
+
             self.set_status(ACCEPTED)
             self.write_json({'staging_order_links': links,
-                             'staging_order_ids': staging_ids_ids})
+                             'staging_order_ids': staging_ids_ids,
+                             'staged_data': project_and_staged_id_dict})
         except ProjectNotFoundException as e:
             log.warning("Request issued for non-existent project {}".format(project_id))
             self.set_status(NOT_FOUND, reason=e.msg)

--- a/delivery/models/__init__.py
+++ b/delivery/models/__init__.py
@@ -1,7 +1,7 @@
 
 
 class BaseModel(object):
-
+    
     def __str__(self):
         return str(self.__dict__)
 

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -38,6 +38,11 @@ class RunfolderProject(BaseProject):
         self.runfolder_path = runfolder_path
         self.runfolder_name = runfolder_name
 
+    def to_dict(self):
+        return {"name": self.name,
+                "path": self.path,
+                "runfolder_path": self.runfolder_path,
+                "runfolder_name": self.runfolder_name}
 
 class GeneralProject(BaseProject):
     """

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -162,7 +162,7 @@ class DeliveryService(object):
         else:
             batch_nbr = max_batch_nbr + 1
 
-        projects_to_deliver= list(self._get_projects_to_deliver(projects, mode, batch_nbr))
+        projects_to_deliver = list(self._get_projects_to_deliver(projects, mode, batch_nbr))
 
         if not projects_to_deliver:
             raise ProjectAlreadyDeliveredException("All runfolders for this project has already "

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -148,7 +148,7 @@ class DeliveryService(object):
 
         :param project_name: of project to deliver
         :param mode: A DeliveryMode
-        :return: a dict with {<project name>: <staging order id>}
+        :return: a tupple with a dict with {<project name>: <staging order id>}, and the projects
         """
         projects = list(self.runfolder_service.find_runfolders_for_project(project_name))
 
@@ -162,7 +162,7 @@ class DeliveryService(object):
         else:
             batch_nbr = max_batch_nbr + 1
 
-        projects_to_deliver = list(self._get_projects_to_deliver(projects, mode, batch_nbr))
+            projects_to_deliver= list(self._get_projects_to_deliver(projects, mode, batch_nbr))
 
         if not projects_to_deliver:
             raise ProjectAlreadyDeliveredException("All runfolders for this project has already "
@@ -176,11 +176,12 @@ class DeliveryService(object):
                                                           source_name="{}/batch{}".format(project_name, batch_nbr),
                                                           path=links_directory,
                                                           batch_nbr=batch_nbr)
+
         self.delivery_sources_repo.add_source(source)
 
         stage_order = self.staging_service.create_new_stage_order(path=source.path, project_name=project_name)
         self.staging_service.stage_order(stage_order)
-        return {source.project_name: stage_order.id}
+        return {source.project_name: stage_order.id}, projects_to_deliver
 
     def deliver_arbitrary_directory_project(self, project_name, dir_name=None, force_delivery=False):
 

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -162,7 +162,7 @@ class DeliveryService(object):
         else:
             batch_nbr = max_batch_nbr + 1
 
-            projects_to_deliver= list(self._get_projects_to_deliver(projects, mode, batch_nbr))
+        projects_to_deliver= list(self._get_projects_to_deliver(projects, mode, batch_nbr))
 
         if not projects_to_deliver:
             raise ProjectAlreadyDeliveredException("All runfolders for this project has already "

--- a/tests/unit_tests/services/test_delivery_service.py
+++ b/tests/unit_tests/services/test_delivery_service.py
@@ -248,7 +248,7 @@ class TestDeliveryService(unittest.TestCase):
             self.assertEqual(projects_and_ids["ABC_123"], 1)
 
             staged_runfolders = list(map(lambda staged_path: staged_path.to_dict(), projects))
-            paths=[]
+            paths = []
             for item in staged_runfolders:
                 paths.append(item['path'])
             self.assertEqual(paths,["/foo/160930_ST-E00216_0112_BH37CWALXX/Projects/ABC_123",

--- a/tests/unit_tests/services/test_delivery_service.py
+++ b/tests/unit_tests/services/test_delivery_service.py
@@ -241,9 +241,12 @@ class TestDeliveryService(unittest.TestCase):
                                            staging_service=staging_service_mock,
                                            project_links_dir=tmpdirname)
 
-            result = self.delivery_service.deliver_all_runfolders_for_project(project_name="ABC_123",
-                                                                              mode=DeliveryMode.CLEAN)
-            self.assertEqual(result["ABC_123"], 1)
+            projects_and_ids, projects = \
+                self.delivery_service.deliver_all_runfolders_for_project(project_name="ABC_123",
+                                                                         mode=DeliveryMode.CLEAN)
+
+            self.assertEqual(projects_and_ids["ABC_123"], 1)
+            # TODO Write test for projects variable
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/services/test_delivery_service.py
+++ b/tests/unit_tests/services/test_delivery_service.py
@@ -246,7 +246,13 @@ class TestDeliveryService(unittest.TestCase):
                                                                          mode=DeliveryMode.CLEAN)
 
             self.assertEqual(projects_and_ids["ABC_123"], 1)
-            # TODO Write test for projects variable
+
+            staged_runfolders = list(map(lambda staged_path: staged_path.to_dict(), projects))
+            paths=[]
+            for item in staged_runfolders:
+                paths.append(item['path'])
+            self.assertEqual(paths,["/foo/160930_ST-E00216_0112_BH37CWALXX/Projects/ABC_123",
+                                    "/foo/160930_ST-E00216_0111_BH37CWALXX/Projects/ABC_123"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What problems does this PR solve?**
It will now be possible for an operator to see staged runfolders by listing the stage_project task in arteria-packs.delivery_runfolders_for_project_workflow on arteria-master

**How has the changes been tested?**
An already existing test is extended to test new changes in this PR. The code has only been tested on the developers local computer.
