### PR TITLE
Develop 509 runfolder organisation service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7-alpine
+
+RUN apk add git
+WORKDIR /arteria-delivery
+
+COPY . .
+RUN pip install --no-cache-dir -r requirements/prod .
+
+
+CMD ["delivery-ws", "--configroot=config/", "--port=8080", "--debug"]

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -18,8 +18,10 @@ from delivery.handlers.project_handlers import ProjectHandler, ProjectsForRunfol
 from delivery.handlers.delivery_handlers import DeliverByStageIdHandler, DeliveryStatusHandler
 from delivery.handlers.staging_handlers import StagingRunfolderHandler, StagingHandler,\
     StageGeneralDirectoryHandler, StagingProjectRunfoldersHandler
+from delivery.handlers.organise_handlers import OrganiseRunfolderHandler
 
-from delivery.repositories.runfolder_repository import FileSystemBasedRunfolderRepository
+from delivery.repositories.runfolder_repository import FileSystemBasedRunfolderRepository, \
+    FileSystemBasedUnorganisedRunfolderRepository
 from delivery.repositories.staging_repository import DatabaseBasedStagingRepository
 from delivery.repositories.deliveries_repository import DatabaseBasedDeliveriesRepository
 from delivery.repositories.project_repository import GeneralProjectRepository
@@ -33,6 +35,7 @@ from delivery.services.file_system_service import FileSystemService
 from delivery.services.delivery_service import DeliveryService
 from delivery.services.runfolder_service import RunfolderService
 from delivery.services.best_practice_analysis_service import BestPracticeAnalysisService
+from delivery.services.organise_service import OrganiseService
 
 
 def routes(**kwargs):
@@ -51,6 +54,9 @@ def routes(**kwargs):
             name="projects_for_runfolder", kwargs=kwargs),
         url(r"/api/1.0/project/([^/]+)/best_practice_samples$", BestPracticeProjectSampleHandler,
             name="best_practice_samples", kwargs=kwargs),
+
+        url(r"/api/1.0/organise/runfolder/(.+)", OrganiseRunfolderHandler,
+            name="organise_runfolder", kwargs=kwargs),
 
         url(r"/api/1.0/stage/project/runfolders/(.+)", StagingProjectRunfoldersHandler,
             name="stage_multiple_runfolders_one_project", kwargs=kwargs),
@@ -110,6 +116,7 @@ def compose_application(config):
     _assert_is_dir(project_links_directory)
 
     runfolder_repo = FileSystemBasedRunfolderRepository(runfolder_dir)
+    unorganised_runfolder_repo = FileSystemBasedUnorganisedRunfolderRepository(runfolder_dir)
 
     general_project_dir = config['general_project_directory']
     _assert_is_dir(general_project_dir)
@@ -157,6 +164,9 @@ def compose_application(config):
 
     best_practice_analysis_service = BestPracticeAnalysisService(general_project_repo)
 
+    organise_service = OrganiseService(
+        runfolder_service=RunfolderService(unorganised_runfolder_repo))
+
     return dict(config=config,
                 runfolder_repo=runfolder_repo,
                 external_program_service=external_program_service,
@@ -164,7 +174,8 @@ def compose_application(config):
                 mover_delivery_service=mover_delivery_service,
                 delivery_service=delivery_service,
                 general_project_repo=general_project_repo,
-                best_practice_analysis_service=best_practice_analysis_service)
+                best_practice_analysis_service=best_practice_analysis_service,
+                organise_service=organise_service)
 
 
 def start():

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -56,7 +56,7 @@ def routes(**kwargs):
         url(r"/api/1.0/project/([^/]+)/best_practice_samples$", BestPracticeProjectSampleHandler,
             name="best_practice_samples", kwargs=kwargs),
 
-        url(r"/api/1.0/organise/runfolder/(.+)", OrganiseRunfolderHandler,
+        url(r"/api/1.0/organise/runfolder/([^/]+)", OrganiseRunfolderHandler,
             name="organise_runfolder", kwargs=kwargs),
 
         url(r"/api/1.0/stage/project/runfolders/(.+)", StagingProjectRunfoldersHandler,

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -24,8 +24,9 @@ from delivery.repositories.runfolder_repository import FileSystemBasedRunfolderR
     FileSystemBasedUnorganisedRunfolderRepository
 from delivery.repositories.staging_repository import DatabaseBasedStagingRepository
 from delivery.repositories.deliveries_repository import DatabaseBasedDeliveriesRepository
-from delivery.repositories.project_repository import GeneralProjectRepository
+from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository
 from delivery.repositories.delivery_sources_repository import DatabaseBasedDeliverySourcesRepository
+from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 
 
 from delivery.services.mover_service import MoverDeliveryService
@@ -116,7 +117,13 @@ def compose_application(config):
     _assert_is_dir(project_links_directory)
 
     runfolder_repo = FileSystemBasedRunfolderRepository(runfolder_dir)
-    unorganised_runfolder_repo = FileSystemBasedUnorganisedRunfolderRepository(runfolder_dir)
+    project_repository = UnorganisedRunfolderProjectRepository(
+        sample_repository=RunfolderProjectBasedSampleRepository()
+    )
+    unorganised_runfolder_repo = FileSystemBasedUnorganisedRunfolderRepository(
+        runfolder_dir,
+        project_repository=project_repository
+    )
 
     general_project_dir = config['general_project_directory']
     _assert_is_dir(general_project_dir)

--- a/delivery/exceptions.py
+++ b/delivery/exceptions.py
@@ -8,10 +8,16 @@ class RunfolderNotFoundException(Exception):
 
 
 class ChecksumNotFoundException(Exception):
+    """
+    Should be raised when a file checksum could not be found in the list of checksums
+    """
     pass
 
 
 class ChecksumFileNotFoundException(Exception):
+    """
+    Should be raised when an expected checksum file could not be found
+    """
     pass
 
 
@@ -70,4 +76,11 @@ class FileNameParsingException(Exception):
 
 
 class SamplesheetNotFoundException(Exception):
+    pass
+
+
+class ProjectsDirNotfoundException(Exception):
+    """
+    Should be raised when a directory containing projects could not be found
+    """
     pass

--- a/delivery/exceptions.py
+++ b/delivery/exceptions.py
@@ -22,6 +22,13 @@ class ProjectNotFoundException(Exception):
     pass
 
 
+class ProjectReportNotFoundException(Exception):
+    """
+    Should be raised when and invalid or non-existent project is searched for.
+    """
+    pass
+
+
 class TooManyProjectsFound(Exception):
     """
     Should be raise when to many projects match some specific criteria

--- a/delivery/exceptions.py
+++ b/delivery/exceptions.py
@@ -7,6 +7,14 @@ class RunfolderNotFoundException(Exception):
     pass
 
 
+class ChecksumNotFoundException(Exception):
+    pass
+
+
+class ChecksumFileNotFoundException(Exception):
+    pass
+
+
 class ProjectNotFoundException(Exception):
     """
     Should be raised when and invalid or non-existent project is searched for.
@@ -51,4 +59,8 @@ class ProjectAlreadyOrganisedException(Exception):
 
 
 class FileNameParsingException(Exception):
+    pass
+
+
+class SamplesheetNotFoundException(Exception):
     pass

--- a/delivery/exceptions.py
+++ b/delivery/exceptions.py
@@ -41,3 +41,14 @@ class ProjectAlreadyDeliveredException(Exception):
     Should be raised when a project has already been delivered.
     """
     pass
+
+
+class ProjectAlreadyOrganisedException(Exception):
+    """
+    Should be raised when a project has already been organised.
+    """
+    pass
+
+
+class FileNameParsingException(Exception):
+    pass

--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -46,7 +46,7 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
 
         """
 
-        log.debug("Trying to organise runfolder with id: {}".format(runfolder_id))
+        log.info("Trying to organise runfolder with id: {}".format(runfolder_id))
 
         try:
             request_data = self.body_as_object()
@@ -58,7 +58,7 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
         projects = request_data.get("projects", [])
 
         if any([force, lanes, projects]):
-            log.debug(
+            log.info(
                 "Got the following 'force', 'lanes' and 'projects' attributes to organise: {}".format(
                     [force, lanes, projects]))
 
@@ -78,6 +78,6 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
         except ProjectAlreadyOrganisedException as e:
             log.error(str(e), exc_info=e)
             self.set_status(FORBIDDEN, reason=str(e))
-        except (FileNameParsingException, Exception) as e:
+        except FileNameParsingException as e:
             log.error(str(e), exc_info=e)
             self.set_status(INTERNAL_SERVER_ERROR, reason=str(e))

--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -73,8 +73,11 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
                 ChecksumFileNotFoundException,
                 SamplesheetNotFoundException,
                 ProjectReportNotFoundException) as e:
+            log.error(str(e), exc_info=e)
             self.set_status(NOT_FOUND, reason=str(e))
         except ProjectAlreadyOrganisedException as e:
+            log.error(str(e), exc_info=e)
             self.set_status(FORBIDDEN, reason=str(e))
         except (FileNameParsingException, Exception) as e:
+            log.error(str(e), exc_info=e)
             self.set_status(INTERNAL_SERVER_ERROR, reason=str(e))

--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -13,7 +13,7 @@ class BaseOrganiseHandler(BaseRestHandler):
 
 class OrganiseRunfolderHandler(BaseOrganiseHandler):
     """
-    Handler class for handling how to start staging of a runfolder.
+    Handler class for handling how to organise a runfolder in preparation for staging and delivery
     """
 
     def initialize(self, organise_service, **kwargs):
@@ -21,16 +21,16 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
 
     def post(self, runfolder_id):
         """
-        Attempt to stage projects from the the specified runfolder, so that they can then be delivered.
-        Will return a set of status links, one for each project that can be queried for the status of
-        that staging attempt. A list of project names can be specified in the request body to limit which projects
-        should be staged. E.g:
+        Attempt to organise projects from the the specified runfolder, so that they can then be staged and delivered.
+        A list of project names and/or lane numbers can be specified in the request body to limit which projects
+        and lanes should be organised. A force flag indicating that previously organised projects should be replaced
+        can also be specified. E.g:
 
             import requests
 
-            url = "http://localhost:8080/api/1.0/stage/runfolder/160930_ST-E00216_0111_BH37CWALXX"
+            url = "http://localhost:8080/api/1.0/organise/runfolder/160930_ST-E00216_0111_BH37CWALXX"
 
-            payload = "{'projects': ['ABC_123']}"
+            payload = "{'projects': ['ABC_123'], 'lanes': [1, 2, 4], 'force': True}"
             headers = {
                 'content-type': "application/json",
             }
@@ -40,7 +40,7 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
             print(response.text)
 
         The return format looks like:
-            {"staging_order_links": {"ABC_123": "http://localhost:8080/api/1.0/stage/584"}}
+            {"organised_path": "/path/to/organised/runfolder/160930_ST-E00216_0111_BH37CWALXX"}
 
         """
 

--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -2,7 +2,9 @@
 import logging
 
 from arteria.web.handlers import BaseRestHandler
-from delivery.handlers import OK, INTERNAL_SERVER_ERROR
+from delivery.exceptions import ProjectsDirNotfoundException, ChecksumFileNotFoundException, FileNameParsingException, \
+    SamplesheetNotFoundException, ProjectReportNotFoundException, ProjectAlreadyOrganisedException
+from delivery.handlers import OK, NOT_FOUND, INTERNAL_SERVER_ERROR, FORBIDDEN
 
 log = logging.getLogger(__name__)
 
@@ -67,7 +69,12 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
             self.write_json({
                 "runfolder": organised_runfolder.path,
                 "projects": [project.name for project in organised_runfolder.projects]})
-
-        except Exception as e:
+        except (ProjectsDirNotfoundException,
+                ChecksumFileNotFoundException,
+                SamplesheetNotFoundException,
+                ProjectReportNotFoundException) as e:
+            self.set_status(NOT_FOUND, reason=str(e))
+        except ProjectAlreadyOrganisedException as e:
+            self.set_status(FORBIDDEN, reason=str(e))
+        except (FileNameParsingException, Exception) as e:
             self.set_status(INTERNAL_SERVER_ERROR, reason=str(e))
-

--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -2,6 +2,7 @@
 import logging
 
 from arteria.web.handlers import BaseRestHandler
+from delivery.handlers import OK, INTERNAL_SERVER_ERROR
 
 log = logging.getLogger(__name__)
 
@@ -57,18 +58,16 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
         if any([force, lanes, projects]):
             log.debug(
                 "Got the following 'force', 'lanes' and 'projects' attributes to organise: {}".format(
-                [force, lanes, projects]))
+                    [force, lanes, projects]))
 
         try:
-            organised_path = self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
+            organised_runfolder = self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
 
             self.set_status(OK)
             self.write_json({
                 "runfolder": organised_runfolder.path,
                 "projects": [project.name for project in organised_runfolder.projects]})
 
-        except ProjectNotFoundException as e:
-            self.set_status(NOT_FOUND, reason=str(e))
-        except ProjectAlreadyDeliveredException as e:
-            self.set_status(FORBIDDEN, reason=str(e))
+        except Exception as e:
+            self.set_status(INTERNAL_SERVER_ERROR, reason=str(e))
 

--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -1,0 +1,74 @@
+
+import logging
+
+from arteria.web.handlers import BaseRestHandler
+
+log = logging.getLogger(__name__)
+
+
+class BaseOrganiseHandler(BaseRestHandler):
+    pass
+
+
+class OrganiseRunfolderHandler(BaseOrganiseHandler):
+    """
+    Handler class for handling how to start staging of a runfolder.
+    """
+
+    def initialize(self, organise_service, **kwargs):
+        self.organise_service = organise_service
+
+    def post(self, runfolder_id):
+        """
+        Attempt to stage projects from the the specified runfolder, so that they can then be delivered.
+        Will return a set of status links, one for each project that can be queried for the status of
+        that staging attempt. A list of project names can be specified in the request body to limit which projects
+        should be staged. E.g:
+
+            import requests
+
+            url = "http://localhost:8080/api/1.0/stage/runfolder/160930_ST-E00216_0111_BH37CWALXX"
+
+            payload = "{'projects': ['ABC_123']}"
+            headers = {
+                'content-type': "application/json",
+            }
+
+            response = requests.request("POST", url, data=payload, headers=headers)
+
+            print(response.text)
+
+        The return format looks like:
+            {"staging_order_links": {"ABC_123": "http://localhost:8080/api/1.0/stage/584"}}
+
+        """
+
+        log.debug("Trying to organise runfolder with id: {}".format(runfolder_id))
+
+        try:
+            request_data = self.body_as_object()
+        except ValueError:
+            request_data = {}
+
+        force = request_data.get("force", False)
+        lanes = request_data.get("lanes", [])
+        projects = request_data.get("projects", [])
+
+        if any([force, lanes, projects]):
+            log.debug(
+                "Got the following 'force', 'lanes' and 'projects' attributes to organise: {}".format(
+                [force, lanes, projects]))
+
+        try:
+            organised_path = self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
+
+            self.set_status(OK)
+            self.write_json({
+                "runfolder": organised_runfolder.path,
+                "projects": [project.name for project in organised_runfolder.projects]})
+
+        except ProjectNotFoundException as e:
+            self.set_status(NOT_FOUND, reason=str(e))
+        except ProjectAlreadyDeliveredException as e:
+            self.set_status(FORBIDDEN, reason=str(e))
+

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -32,6 +32,7 @@ class RunfolderProject(BaseProject):
         :param path: path to the project
         :param runfolder_path: path the runfolder in which this project is stored.
         :param runfolder_name: name of the runfolder in which this project is stored
+        :param samples: list of instances of Sample, representing samples in the project
         """
         self.name = name
         self.path = os.path.abspath(path)

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -28,7 +28,7 @@ class RunfolderProject(BaseProject):
     to the idea of projects as subdirectories in a demultiplexed Illumina runfolder.
     """
 
-    def __init__(self, name, path, runfolder_path, runfolder_name, samples=None):
+    def __init__(self, name, path, runfolder_path, runfolder_name, samples=None, project_files=None):
         """
         Instantiate a new `RunfolderProject` object
         :param name: of the project
@@ -42,13 +42,15 @@ class RunfolderProject(BaseProject):
         self.runfolder_path = runfolder_path
         self.runfolder_name = runfolder_name
         self.samples = samples
+        self.project_files = project_files
 
     def to_dict(self):
         return {"name": self.name,
                 "path": self.path,
                 "runfolder_path": self.runfolder_path,
                 "runfolder_name": self.runfolder_name,
-                "samples": self.samples}
+                "samples": self.samples,
+                "project_files": self.project_files}
 
     def __hash__(self):
         return hash((
@@ -57,10 +59,11 @@ class RunfolderProject(BaseProject):
             self.runfolder_path,
             self.runfolder_path,
             self.runfolder_name,
-            self.samples))
+            self.samples,
+            self.project_files))
 
     def __eq__(self, other):
-        return super().__eq__(other) and other.samples == self.samples
+        return super().__eq__(other) and other.samples == self.samples and other.project_files == self.project_files
 
 
 class GeneralProject(BaseProject):

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -44,6 +44,7 @@ class RunfolderProject(BaseProject):
                 "runfolder_path": self.runfolder_path,
                 "runfolder_name": self.runfolder_name}
 
+
 class GeneralProject(BaseProject):
     """
     Model representing a project as a directory on disk.

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -25,7 +25,7 @@ class RunfolderProject(BaseProject):
     to the idea of projects as subdirectories in a demultiplexed Illumina runfolder.
     """
 
-    def __init__(self, name, path, runfolder_path, runfolder_name):
+    def __init__(self, name, path, runfolder_path, runfolder_name, samples=None):
         """
         Instantiate a new `RunfolderProject` object
         :param name: of the project
@@ -37,12 +37,14 @@ class RunfolderProject(BaseProject):
         self.path = os.path.abspath(path)
         self.runfolder_path = runfolder_path
         self.runfolder_name = runfolder_name
+        self.samples = samples
 
     def to_dict(self):
         return {"name": self.name,
                 "path": self.path,
                 "runfolder_path": self.runfolder_path,
-                "runfolder_name": self.runfolder_name}
+                "runfolder_name": self.runfolder_name,
+                "samples": self.samples}
 
 
 class GeneralProject(BaseProject):

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -18,6 +18,9 @@ class BaseProject(BaseModel):
             return self.path == other.path
         return False
 
+    def __hash__(self):
+        return hash((self.__class__, self.path))
+
 
 class RunfolderProject(BaseProject):
     """
@@ -46,6 +49,15 @@ class RunfolderProject(BaseProject):
                 "runfolder_path": self.runfolder_path,
                 "runfolder_name": self.runfolder_name,
                 "samples": self.samples}
+
+    def __hash__(self):
+        return hash((
+            super().__hash__(),
+            self.name,
+            self.runfolder_path,
+            self.runfolder_path,
+            self.runfolder_name,
+            self.samples))
 
     def __eq__(self, other):
         return super().__eq__(other) and other.samples == self.samples

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -46,6 +46,9 @@ class RunfolderProject(BaseProject):
                 "runfolder_name": self.runfolder_name,
                 "samples": self.samples}
 
+    def __eq__(self, other):
+        return super().__eq__(other) and other.samples == self.samples
+
 
 class GeneralProject(BaseProject):
     """

--- a/delivery/models/runfolder.py
+++ b/delivery/models/runfolder.py
@@ -9,7 +9,7 @@ class Runfolder(BaseModel):
     Models the concept of a runfolder on disk
     """
 
-    def __init__(self, name, path, projects=None):
+    def __init__(self, name, path, projects=None, checksums=None):
         """
         Instantiate a new runfolder instance
         :param name: of the runfolder
@@ -19,6 +19,7 @@ class Runfolder(BaseModel):
         self.name = name
         self.path = os.path.abspath(path)
         self.projects = projects
+        self.checksums = checksums
 
     def __eq__(self, other):
         """

--- a/delivery/models/runfolder.py
+++ b/delivery/models/runfolder.py
@@ -33,3 +33,11 @@ class Runfolder(BaseModel):
 
     def __hash__(self):
         return hash((self.name, self.path, self.projects))
+
+
+class RunfolderFile(object):
+
+    def __init__(self, file_path, file_checksum=None):
+        self.file_path = os.path.abspath(file_path)
+        self.file_name = os.path.basename(file_path)
+        self.checksum = file_checksum

--- a/delivery/models/runfolder.py
+++ b/delivery/models/runfolder.py
@@ -30,3 +30,6 @@ class Runfolder(BaseModel):
         if isinstance(other, self.__class__):
             return self.path == other.path
         return False
+
+    def __hash__(self):
+        return hash((self.name, self.path, self.projects))

--- a/delivery/models/sample.py
+++ b/delivery/models/sample.py
@@ -27,6 +27,9 @@ class Sample(object):
                other.project_name == self.project_name and \
                other.sample_files == self.sample_files
 
+    def __hash__(self):
+        return hash((self.name, self.sample_id, self.project_name, self.sample_files))
+
 
 class SampleFile(object):
     """
@@ -64,3 +67,14 @@ class SampleFile(object):
 
     def __eq__(self, other):
         return other.sample_path == self.sample_path and other.checksum == self.checksum
+
+    def __hash__(self):
+        return hash((
+            self.sample_path,
+            self.file_name,
+            self.sample_name,
+            self.sample_index,
+            self.lane_no,
+            self.read_no,
+            self.is_index,
+            self.checksum))

--- a/delivery/models/sample.py
+++ b/delivery/models/sample.py
@@ -12,11 +12,22 @@ class Sample(object):
 
 class SampleFile(object):
 
-    def __init__(self, sample_path, sample_name=None, sample_index=None, lane_no=None, read_no=None, is_index=None):
+    def __init__(
+            self,
+            sample_path,
+            sample_id=None,
+            sample_name=None,
+            sample_index=None,
+            lane_no=None,
+            read_no=None,
+            is_index=None,
+            checksum=None):
         self.sample_path = os.path.abspath(sample_path)
         self.file_name = os.path.basename(sample_path)
         self.sample_name = sample_name
+        self.sample_id = sample_id or self.sample_name
         self.sample_index = sample_index
         self.lane_no = lane_no
         self.read_no = read_no
         self.is_index = is_index
+        self.checksum = checksum

--- a/delivery/models/sample.py
+++ b/delivery/models/sample.py
@@ -1,6 +1,8 @@
 
 import os
 
+from delivery.models.runfolder import RunfolderFile
+
 
 class Sample(object):
     """
@@ -31,7 +33,7 @@ class Sample(object):
         return hash((self.name, self.sample_id, self.project_name, self.sample_files))
 
 
-class SampleFile(object):
+class SampleFile(RunfolderFile):
     """
     Models the concept of a sequence file belonging to a sample
     """
@@ -56,21 +58,19 @@ class SampleFile(object):
         :param is_index: if True, the sequence file contains index sequences
         :param checksum: the MD5 checksum for this SampleFile
         """
-        self.sample_path = os.path.abspath(sample_path)
-        self.file_name = os.path.basename(sample_path)
+        super(SampleFile, self).__init__(sample_path, file_checksum=checksum)
         self.sample_name = sample_name
         self.sample_index = sample_index
         self.lane_no = lane_no
         self.read_no = read_no
         self.is_index = is_index
-        self.checksum = checksum
 
     def __eq__(self, other):
-        return other.sample_path == self.sample_path and other.checksum == self.checksum
+        return other.file_path == self.file_path and other.checksum == self.checksum
 
     def __hash__(self):
         return hash((
-            self.sample_path,
+            self.file_path,
             self.file_name,
             self.sample_name,
             self.sample_index,

--- a/delivery/models/sample.py
+++ b/delivery/models/sample.py
@@ -4,10 +4,17 @@ import os
 
 class Sample(object):
 
-    def __init__(self, name, project_name, sample_files=None):
+    def __init__(self, name, project_name, sample_id=None, sample_files=None):
         self.name = name
+        self.sample_id = sample_id or self.name
         self.project_name = project_name
         self.sample_files = sample_files
+
+    def __eq__(self, other):
+        return other.name == self.name and \
+               other.sample_id == self.sample_id and \
+               other.project_name == self.project_name and \
+               other.sample_files == self.sample_files
 
 
 class SampleFile(object):
@@ -15,7 +22,6 @@ class SampleFile(object):
     def __init__(
             self,
             sample_path,
-            sample_id=None,
             sample_name=None,
             sample_index=None,
             lane_no=None,
@@ -25,9 +31,11 @@ class SampleFile(object):
         self.sample_path = os.path.abspath(sample_path)
         self.file_name = os.path.basename(sample_path)
         self.sample_name = sample_name
-        self.sample_id = sample_id or self.sample_name
         self.sample_index = sample_index
         self.lane_no = lane_no
         self.read_no = read_no
         self.is_index = is_index
         self.checksum = checksum
+
+    def __eq__(self, other):
+        return other.sample_path == self.sample_path and other.checksum == self.checksum

--- a/delivery/models/sample.py
+++ b/delivery/models/sample.py
@@ -3,8 +3,19 @@ import os
 
 
 class Sample(object):
+    """
+    Models the concept of a sample on disk
+    """
 
     def __init__(self, name, project_name, sample_id=None, sample_files=None):
+        """
+        Instantiate a new `Sample` object.
+
+        :param name: the sample name, typically used as a prefix in the sample file name
+        :param project_name: the name of the project the sample belongs to
+        :param sample_id: the sample id, can be different from sample name but is typically the same
+        :param sample_files: a list of SampleFile instances representing sequence files belonging to the sample
+        """
         self.name = name
         self.sample_id = sample_id or self.name
         self.project_name = project_name
@@ -18,6 +29,9 @@ class Sample(object):
 
 
 class SampleFile(object):
+    """
+    Models the concept of a sequence file belonging to a sample
+    """
 
     def __init__(
             self,
@@ -28,6 +42,17 @@ class SampleFile(object):
             read_no=None,
             is_index=None,
             checksum=None):
+        """
+        Instantiate a new `SampleFile` object
+
+        :param sample_path: the path to the file
+        :param sample_name: the name of the sample
+        :param sample_index: the sample index designator
+        :param lane_no: the lane number the sequences in the file were derived from
+        :param read_no: the read number
+        :param is_index: if True, the sequence file contains index sequences
+        :param checksum: the MD5 checksum for this SampleFile
+        """
         self.sample_path = os.path.abspath(sample_path)
         self.file_name = os.path.basename(sample_path)
         self.sample_name = sample_name

--- a/delivery/models/sample.py
+++ b/delivery/models/sample.py
@@ -1,0 +1,22 @@
+
+import os
+
+
+class Sample(object):
+
+    def __init__(self, name, project_name, sample_files=None):
+        self.name = name
+        self.project_name = project_name
+        self.sample_files = sample_files
+
+
+class SampleFile(object):
+
+    def __init__(self, sample_path, sample_name=None, sample_index=None, lane_no=None, read_no=None, is_index=None):
+        self.sample_path = os.path.abspath(sample_path)
+        self.file_name = os.path.basename(sample_path)
+        self.sample_name = sample_name
+        self.sample_index = sample_index
+        self.lane_no = lane_no
+        self.read_no = read_no
+        self.is_index = is_index

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -55,6 +55,10 @@ class GeneralProjectRepository(object):
 
 
 class UnorganisedRunfolderProjectRepository(object):
+    """
+    Repository for a unorganised project in a runfolder. For this purpose a project is represented by a directory under
+    the runfolder's PROJECTS_DIR directory, having at least one fastq file beneath it.
+    """
 
     PROJECTS_DIR = "Unaligned"
 
@@ -69,6 +73,12 @@ class UnorganisedRunfolderProjectRepository(object):
         self.sample_repository = sample_repository
 
     def dump_checksums(self, project):
+        """
+        Writes checksums for files relevant to the supplied project to a file under the project path.
+
+        :param project: an instance of Project
+        :return: the path to the created checksum file
+        """
 
         def _sample_file_checksum(sample_file):
             return [

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -200,10 +200,11 @@ class UnorganisedRunfolderProjectRepository(object):
         :param sample_lane: the lane the sample to search for was sequenced on
         :return: True if a matching sample could be found, False otherwise
         """
+        sample_obj = self.get_sample(project, sample_id)
         return all([
             sample_project == project.name,
-            self.get_sample(project, sample_id),
-            sample_lane in self.sample_repository.sample_lanes(self.get_sample(project, sample_id))])
+            sample_obj,
+            sample_lane in self.sample_repository.sample_lanes(sample_obj)])
 
     @staticmethod
     def get_sample(project, sample_id):

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -4,7 +4,8 @@ import os
 
 from delivery.services.file_system_service import FileSystemService
 from delivery.models.project import GeneralProject, RunfolderProject
-from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException, ProjectReportNotFoundException
+from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException, ProjectReportNotFoundException, \
+    ProjectsDirNotfoundException
 
 log = logging.getLogger(__name__)
 
@@ -104,6 +105,7 @@ class UnorganisedRunfolderProjectRepository(object):
 
         :param runfolder: a Runfolder instance
         :return: a list of RunfolderProject instances or None if no projects were found
+        :raises: ProjectsDirNotfoundException if the Unaligned directory could not be found in the runfolder
         """
         def dir_contains_fastq_files(d):
             return any(
@@ -130,13 +132,10 @@ class UnorganisedRunfolderProjectRepository(object):
                 self.filesystem_service.find_project_directories(projects_base_dir)
             )
 
-            # There are scenarios where there are no project directories in the runfolder,
-            # i.e. when fastq files have not yet been divided into projects
             return list(map(project_from_dir, project_directories)) or None
 
         except FileNotFoundError:
-            log.warning("Did not find Unaligned folder for: {}".format(runfolder.name))
-            pass
+            raise ProjectsDirNotfoundException("Did not find Unaligned folder for: {}".format(runfolder.name))
 
     def get_report_files(self, project):
         """

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from delivery.services.file_system_service import FileSystemService
+from delivery.services.metadata_service import MetadataService
 from delivery.models.project import GeneralProject, RunfolderProject
 from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException, ProjectReportNotFoundException, \
     ProjectsDirNotfoundException
@@ -63,7 +64,7 @@ class UnorganisedRunfolderProjectRepository(object):
 
     PROJECTS_DIR = "Unaligned"
 
-    def __init__(self, sample_repository, filesystem_service=FileSystemService()):
+    def __init__(self, sample_repository, filesystem_service=FileSystemService(), metadata_service=MetadataService()):
         """
         Instantiate a new UnorganisedRunfolderProjectRepository object
 
@@ -72,6 +73,7 @@ class UnorganisedRunfolderProjectRepository(object):
         """
         self.filesystem_service = filesystem_service
         self.sample_repository = sample_repository
+        self.metadata_service = metadata_service
 
     def dump_checksums(self, project):
         """
@@ -93,7 +95,7 @@ class UnorganisedRunfolderProjectRepository(object):
                 yield _sample_file_checksum(sample_file)
 
         checksum_path = os.path.join(project.path, "checksums.md5")
-        self.filesystem_service.write_checksum_file(
+        self.metadata_service.write_checksum_file(
             checksum_path,
             {path: checksum for sample in project.samples for checksum, path in _sample_checksums(sample) if checksum})
 

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -4,7 +4,7 @@ import os
 
 from delivery.services.file_system_service import FileSystemService
 from delivery.models.project import GeneralProject, RunfolderProject
-from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException
+from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException, ProjectReportNotFoundException
 
 log = logging.getLogger(__name__)
 

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -222,10 +222,11 @@ class UnorganisedRunfolderProjectRepository(object):
         :return: True if a matching sample could be found, False otherwise
         """
         sample_obj = self.get_sample(project, sample_id)
+        sample_lanes = self.sample_repository.sample_lanes(sample_obj) if sample_obj else []
         return all([
             sample_project == project.name,
             sample_obj,
-            sample_lane in self.sample_repository.sample_lanes(sample_obj)])
+            sample_lane in sample_lanes])
 
     @staticmethod
     def get_sample(project, sample_id):

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -1,9 +1,12 @@
 
+import logging
 import os
 
 from delivery.services.file_system_service import FileSystemService
-from delivery.models.project import GeneralProject
+from delivery.models.project import GeneralProject, RunfolderProject
 from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException
+
+log = logging.getLogger(__name__)
 
 
 class GeneralProjectRepository(object):
@@ -49,3 +52,150 @@ class GeneralProjectRepository(object):
 
         exact_project = matching_project[0]
         return exact_project
+
+
+class UnorganisedRunfolderProjectRepository(object):
+
+    PROJECTS_DIR = "Unaligned"
+
+    def __init__(self, sample_repository, filesystem_service=FileSystemService()):
+        """
+        Instantiate a new UnorganisedRunfolderProjectRepository object
+
+        :param sample_repository: a RunfolderProjectBasedSampleRepository instance
+        :param filesystem_service:  a FileSystemService instance for accessing the file system
+        """
+        self.filesystem_service = filesystem_service
+        self.sample_repository = sample_repository
+
+    def dump_checksums(self, project):
+
+        def _sample_file_checksum(sample_file):
+            return [
+                sample_file.checksum,
+                self.filesystem_service.relpath(
+                    sample_file.sample_path,
+                    project.path)] if sample_file.checksum else None
+
+        def _sample_checksums(sample):
+            for sample_file in sample.sample_files:
+                yield _sample_file_checksum(sample_file)
+
+        checksum_path = os.path.join(project.path, "checksums.md5")
+        self.filesystem_service.write_checksum_file(
+            checksum_path,
+            {path: checksum for sample in project.samples for checksum, path in _sample_checksums(sample) if checksum})
+
+        return checksum_path
+
+    def get_projects(self, runfolder):
+        """
+        Returns a list of RunfolderProject instances, representing all projects found in this runfolder.
+
+        :param runfolder: a Runfolder instance
+        :return: a list of RunfolderProject instances or None if no projects were found
+        """
+        def dir_contains_fastq_files(d):
+            return any(
+                map(
+                    lambda f: f.endswith("fastq.gz"),
+                    self.filesystem_service.list_files_recursively(d)))
+
+        def project_from_dir(d):
+            project = RunfolderProject(
+                name=os.path.basename(d),
+                path=os.path.join(projects_base_dir, d),
+                runfolder_path=runfolder.path,
+                runfolder_name=runfolder.name
+            )
+            project.samples = self.sample_repository.get_samples(project, runfolder)
+            return project
+
+        try:
+            projects_base_dir = os.path.join(runfolder.path, self.PROJECTS_DIR)
+
+            # only include directories that have fastq.gz files beneath them
+            project_directories = filter(
+                dir_contains_fastq_files,
+                self.filesystem_service.find_project_directories(projects_base_dir)
+            )
+
+            # There are scenarios where there are no project directories in the runfolder,
+            # i.e. when fastq files have not yet been divided into projects
+            return list(map(project_from_dir, project_directories)) or None
+
+        except FileNotFoundError:
+            log.warning("Did not find Unaligned folder for: {}".format(runfolder.name))
+            pass
+
+    def get_report_files(self, project):
+        """
+        Gets the paths to files associated with the supplied project's report. This can be either a MultiQC report or,
+        if no such report was found, a Sisyphus report.
+
+        :param project: a RunfolderProject instance
+        :return: a tuple with the path to the directory containing the report files and a list of the paths to the
+        report files
+        :raises ProjectReportNotFoundException: if no MultiQC or Sisyphus report was found for the project
+        """
+        if self.filesystem_service.exists(self.multiqc_report_path(project)):
+            return self.multiqc_report_files(project)
+        for sisyphus_report_path in self.sisyphus_report_path(project):
+            if self.filesystem_service.exists(sisyphus_report_path):
+                return self.sisyphus_report_files(
+                    self.filesystem_service.dirname(sisyphus_report_path))
+        raise ProjectReportNotFoundException("No project report found for {}".format(project.name))
+
+    @staticmethod
+    def sisyphus_report_path(project):
+        return os.path.join(
+            project.runfolder_path, "Summary", project.name, "report.html"), \
+               os.path.join(
+                   project.path, "report.html")
+
+    def sisyphus_report_files(self, report_dir):
+        report_files = [
+            os.path.join(report_dir, "report.html"),
+            os.path.join(report_dir, "report.xml"),
+            os.path.join(report_dir, "report.xsl")
+        ]
+        report_files.extend(list(
+            self.filesystem_service.list_files_recursively(
+                os.path.join(
+                    report_dir,
+                    "Plots"))))
+        return report_dir, report_files
+
+    @staticmethod
+    def multiqc_report_path(project):
+        return os.path.join(
+            project.path,
+            "{}_multiqc_report.html".format(project.name))
+
+    def multiqc_report_files(self, project):
+        report_files = [self.multiqc_report_path(project)]
+        report_dir = self.filesystem_service.dirname(report_files[0])
+        report_files.append(
+            os.path.join(report_dir, "{}_multiqc_report_data.zip".format(project.name)))
+        return report_dir, report_files
+
+    def is_sample_in_project(self, project, sample_project, sample_id, sample_lane):
+        """
+        Checks if a matching sample is present in the project.
+
+        :param project: a Project instance in which to search for a matching sample
+        :param sample_project: the project name of the sample to search for
+        :param sample_id: the sample id of the sample to search for
+        :param sample_lane: the lane the sample to search for was sequenced on
+        :return: True if a matching sample could be found, False otherwise
+        """
+        return all([
+            sample_project == project.name,
+            self.get_sample(project, sample_id),
+            sample_lane in self.sample_repository.sample_lanes(self.get_sample(project, sample_id))])
+
+    @staticmethod
+    def get_sample(project, sample_id):
+        for sample in project.samples:
+            if sample.sample_id == sample_id:
+                return sample

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -5,6 +5,7 @@ import os
 from delivery.services.file_system_service import FileSystemService
 from delivery.services.metadata_service import MetadataService
 from delivery.models.project import GeneralProject, RunfolderProject
+from delivery.models.runfolder import RunfolderFile
 from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException, ProjectReportNotFoundException, \
     ProjectsDirNotfoundException
 
@@ -87,17 +88,23 @@ class UnorganisedRunfolderProjectRepository(object):
             return [
                 sample_file.checksum,
                 self.filesystem_service.relpath(
-                    sample_file.sample_path,
+                    sample_file.file_path,
                     project.path)] if sample_file.checksum else None
 
         def _sample_checksums(sample):
             for sample_file in sample.sample_files:
                 yield _sample_file_checksum(sample_file)
 
-        checksum_path = os.path.join(project.path, "checksums.md5")
+        checksum_path = os.path.join(project.path, project.runfolder_name, "checksums.md5")
+        checksums = {
+            path: checksum for sample in project.samples for checksum, path in _sample_checksums(sample) if checksum}
+        checksums.update({
+            self.filesystem_service.relpath(
+                project_file.file_path,
+                project.path): project_file.checksum for project_file in project.project_files})
         self.metadata_service.write_checksum_file(
             checksum_path,
-            {path: checksum for sample in project.samples for checksum, path in _sample_checksums(sample) if checksum})
+            checksums)
 
         return checksum_path
 
@@ -122,6 +129,7 @@ class UnorganisedRunfolderProjectRepository(object):
                 runfolder_path=runfolder.path,
                 runfolder_name=runfolder.name
             )
+            project.project_files = self.get_report_files(project, checksums=runfolder.checksums)
             project.samples = self.sample_repository.get_samples(project, runfolder)
             return project
 
@@ -139,22 +147,35 @@ class UnorganisedRunfolderProjectRepository(object):
         except FileNotFoundError:
             raise ProjectsDirNotfoundException("Did not find Unaligned folder for: {}".format(runfolder.name))
 
-    def get_report_files(self, project):
+    def get_report_files(self, project, checksums=None):
         """
         Gets the paths to files associated with the supplied project's report. This can be either a MultiQC report or,
-        if no such report was found, a Sisyphus report.
+        if no such report was found, a Sisyphus report. If a pre-calculated checksum cannot be found for a file, it will
+        be calculated on-the-fly.
 
         :param project: a RunfolderProject instance
-        :return: a tuple with the path to the directory containing the report files and a list of the paths to the
-        report files
+        :param checksums: a dict with pre-calculated checksums for files. paths are keys and the corresponding
+        checksum is the value
+        :return: a list of RunfolderFile objects
         :raises ProjectReportNotFoundException: if no MultiQC or Sisyphus report was found for the project
         """
+        def _file_object_from_path(file_path):
+            relative_file_path = self.filesystem_service.relpath(
+                file_path,
+                self.filesystem_service.dirname(project.runfolder_path))
+            checksum = checksums[relative_file_path] \
+                if relative_file_path in checksums else self.metadata_service.hash_file(file_path)
+            return RunfolderFile(file_path, file_checksum=checksum)
+
+        checksums = checksums or {}
         if self.filesystem_service.exists(self.multiqc_report_path(project)):
-            return self.multiqc_report_files(project)
+            return list(map(_file_object_from_path, self.multiqc_report_files(project)))
         for sisyphus_report_path in self.sisyphus_report_path(project):
             if self.filesystem_service.exists(sisyphus_report_path):
-                return self.sisyphus_report_files(
-                    self.filesystem_service.dirname(sisyphus_report_path))
+                return list(map(
+                    _file_object_from_path,
+                    self.sisyphus_report_files(
+                        self.filesystem_service.dirname(sisyphus_report_path))))
         raise ProjectReportNotFoundException("No project report found for {}".format(project.name))
 
     @staticmethod
@@ -175,7 +196,7 @@ class UnorganisedRunfolderProjectRepository(object):
                 os.path.join(
                     report_dir,
                     "Plots"))))
-        return report_dir, report_files
+        return report_files
 
     @staticmethod
     def multiqc_report_path(project):
@@ -188,7 +209,7 @@ class UnorganisedRunfolderProjectRepository(object):
         report_dir = self.filesystem_service.dirname(report_files[0])
         report_files.append(
             os.path.join(report_dir, "{}_multiqc_report_data.zip".format(project.name)))
-        return report_dir, report_files
+        return report_files
 
     def is_sample_in_project(self, project, sample_project, sample_id, sample_lane):
         """

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -134,6 +134,9 @@ class FileSystemBasedRunfolderRepository(object):
 
 
 class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepository):
+    """
+    A subclass of `FileSystemBasedRunfolderRepository` providing functionality for a unorganised runfolder
+    """
 
     def __init__(self, base_path, project_repository, file_system_service=FileSystemService()):
         """
@@ -152,6 +155,13 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
         runfolder.projects = self.project_repository.get_projects(runfolder)
 
     def dump_project_checksums(self, project):
+        """
+        Calls the `UnorganisedRunfolderProjectRepository` instance associated with this repository to dump out
+        checksums for files relevant to the supplied project to a file under the project path.
+
+        :param project: an instance of Project
+        :return: the path to the created checksum file
+        """
         return self.project_repository.dump_checksums(project)
 
     def dump_project_samplesheet(self, runfolder, project):
@@ -176,14 +186,6 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
                 e.get("Sample_Project"),
                 e.get("Sample_ID"),
                 int(e.get("Lane")))
-
-        def _samplesheet_entry_in_project(e):
-            return all([
-                e.get("Sample_Project") == project.name,
-                e.get("Sample_ID") in [
-                    sample.sample_id for sample in project.samples],
-                int(e.get("Lane")) in [
-                    lane for sample in project.samples for lane in self.sample_repository.sample_lanes(sample)]])
 
         samplesheet_data = self.get_samplesheet(runfolder)
         project_samplesheet_data = list(filter(_samplesheet_entry_in_project, samplesheet_data))

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -202,7 +202,8 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
                 project,
                 e.get("Sample_Project"),
                 e.get("Sample_ID"),
-                int(e.get("Lane")))
+                # e.g. MiSeq SampleSheets may not have the Lane column, so assume 1 if missing
+                int(e.get("Lane", "1")))
 
         def _mask_samplesheet_entry(e):
             """

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -129,9 +129,6 @@ class FileSystemBasedRunfolderRepository(object):
             if project.name == project_name:
                 yield project
 
-    def dump_project_checksums(self, project):
-        raise NotImplementedError()
-
     def samplesheet_file(self, runfolder):
         return os.path.join(runfolder.path, self.SAMPLESHEET_PATH)
 

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -5,7 +5,7 @@ import os
 import re
 
 from delivery.exceptions import ChecksumFileNotFoundException
-from delivery.models.runfolder import Runfolder
+from delivery.models.runfolder import Runfolder, RunfolderFile
 from delivery.models.project import RunfolderProject
 from delivery.services.file_system_service import FileSystemService
 from delivery.services.metadata_service import MetadataService
@@ -81,8 +81,8 @@ class FileSystemBasedRunfolderRepository(object):
         name = os.path.basename(directory)
         path = os.path.join(self._base_path, directory)
         runfolder = Runfolder(name=name, path=path, projects=None)
-        self._add_projects_to_runfolder(runfolder)
         self._add_checksums_for_runfolder(runfolder, ignore_errors=ignore_errors)
+        self._add_projects_to_runfolder(runfolder)
         return runfolder
 
     def _get_runfolders(self, ignore_errors=False):
@@ -189,7 +189,7 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
 
         :param runfolder: an instance of Runfolder
         :param project: an instance of Project
-        :return: the path to the created SampleSheet file
+        :return: a RunfolderFile object representing the written samplesheet file
         """
         def _samplesheet_entry_in_project(e):
             """
@@ -224,11 +224,14 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
         samplesheet_data = self.get_samplesheet(runfolder)
         # mask all entries not belonging to the project and write the resulting data to the project-specific location
         project_samplesheet_data = list(map(_mask_samplesheet_entry, samplesheet_data))
-        project_samplesheet_file = os.path.join(project.path, self.SAMPLESHEET_PATH)
+        project_samplesheet_file = os.path.join(project.path, runfolder.name, self.SAMPLESHEET_PATH)
         self.metadata_service.write_samplesheet_file(project_samplesheet_file, project_samplesheet_data)
-        return project_samplesheet_file
+        return RunfolderFile(
+            project_samplesheet_file,
+            file_checksum=self.metadata_service.hash_file(
+                project_samplesheet_file))
 
-    def get_project_report_files(self, project):
+    def get_project_report_files(self, runfolder, project):
         """
         Calls the `UnorganisedRunfolderProjectRepository` instance associated with this repository to collect
         paths to report files relevant to the supplied project.
@@ -236,4 +239,4 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
         :param project: an instance of Project
         :return: a tuple with the path to the directory containing the report and a list of paths to the report files
         """
-        return self.project_repository.get_report_files(project)
+        return self.project_repository.get_report_files(project, checksums=runfolder.checksums)

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 
-from delivery.exceptions import ChecksumFileNotFoundException
 from delivery.models.runfolder import Runfolder
 from delivery.models.project import RunfolderProject
 from delivery.services.file_system_service import FileSystemService
@@ -74,10 +73,7 @@ class FileSystemBasedRunfolderRepository(object):
 
                 runfolder = Runfolder(name=name, path=path, projects=None)
                 self._add_projects_to_runfolder(runfolder)
-                try:
-                    self._add_checksums_for_runfolder(runfolder)
-                except ChecksumFileNotFoundException as e:
-                    log.info(e)
+                self._add_checksums_for_runfolder(runfolder)
 
                 yield runfolder
 

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -132,18 +132,6 @@ class FileSystemBasedRunfolderRepository(object):
     def get_samplesheet(self, runfolder):
         return self.file_system_service.extract_samplesheet_data(self.samplesheet_file(runfolder))
 
-    def dump_project_samplesheet(self, runfolder, project):
-
-        def _samplesheet_entry_in_project(e):
-            # TODO: check also lane, sample and index
-            return e.get("Sample_Project") == project.name
-
-        samplesheet_data = self.get_samplesheet(runfolder)
-        project_samplesheet_data = list(filter(_samplesheet_entry_in_project, samplesheet_data))
-        project_samplesheet_file = os.path.join(project.path, self.SAMPLESHEET_PATH)
-        self.file_system_service.write_samplesheet_file(project_samplesheet_file, project_samplesheet_data)
-        return project_samplesheet_file
-
 
 class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepository):
 
@@ -188,6 +176,14 @@ class FileSystemBasedUnorganisedRunfolderRepository(FileSystemBasedRunfolderRepo
                 e.get("Sample_Project"),
                 e.get("Sample_ID"),
                 int(e.get("Lane")))
+
+        def _samplesheet_entry_in_project(e):
+            return all([
+                e.get("Sample_Project") == project.name,
+                e.get("Sample_ID") in [
+                    sample.sample_id for sample in project.samples],
+                int(e.get("Lane")) in [
+                    lane for sample in project.samples for lane in self.sample_repository.sample_lanes(sample)]])
 
         samplesheet_data = self.get_samplesheet(runfolder)
         project_samplesheet_data = list(filter(_samplesheet_entry_in_project, samplesheet_data))

--- a/delivery/repositories/sample_repository.py
+++ b/delivery/repositories/sample_repository.py
@@ -38,7 +38,7 @@ class RunfolderProjectBasedSampleRepository(object):
             return re.match(self.filename_regexp, f) is not None
 
         def _name_from_sample_file(s):
-            subdir = self.file_system_service.relpath(os.path.dirname(s.sample_path), project.path)
+            subdir = self.file_system_service.relpath(os.path.dirname(s.file_path), project.path)
             return s.sample_name, subdir if subdir != "." else None
 
         def _sample_from_name(name_id):

--- a/delivery/repositories/sample_repository.py
+++ b/delivery/repositories/sample_repository.py
@@ -27,10 +27,11 @@ class RunfolderProjectBasedSampleRepository(object):
             return re.match(self.filename_regexp, f) is not None
 
         def _name_from_sample_file(s):
-            return s.sample_name
+            subdir = self.file_system_service.relpath(os.path.dirname(s.sample_path), project.path)
+            return s.sample_name, subdir if subdir != "." else None
 
-        def _sample_from_name(n):
-            return Sample(n, project.name)
+        def _sample_from_name(name_id):
+            return Sample(name_id[0], project.name, sample_id=name_id[1])
 
         def _sample_file_from_path(p):
             return self.sample_file_from_sample_path(p, runfolder)
@@ -88,4 +89,9 @@ class RunfolderProjectBasedSampleRepository(object):
             read_no=read_no,
             is_index=is_index,
             checksum=checksum)
+
+    @staticmethod
+    def sample_lanes(sample):
+        return list(set([
+            sample_file.lane_no for sample_file in sample.sample_files]))
 

--- a/delivery/repositories/sample_repository.py
+++ b/delivery/repositories/sample_repository.py
@@ -1,0 +1,72 @@
+
+import logging
+import os
+import re
+
+from delivery.exceptions import FileNameParsingException
+from delivery.models.sample import Sample, SampleFile
+
+from delivery.services.file_system_service import FileSystemService
+
+log = logging.getLogger(__name__)
+
+
+class RunfolderProjectBasedSampleRepository(object):
+
+    filename_regexp = r'^(.+)_(S\d+)_L00(\d+)_([IR])(\d)_\d+\.fastq\.gz$'
+
+    def __init__(self, file_system_service=FileSystemService()):
+        self.file_system_service = file_system_service
+
+    def get_samples(self, project):
+        return self._get_samples(project)
+
+    def _get_samples(self, project):
+
+        def _is_fastq_file(f):
+            return re.match(self.filename_regexp, f) is not None
+
+        def _name_from_sample_file(s):
+            return s.sample_name
+
+        def _sample_from_name(n):
+            return Sample(n, project.name)
+
+        project_fastq_files = filter(
+            _is_fastq_file,
+            self.file_system_service.list_files_recursively(project.path))
+
+        # create SampleFile objects from the paths, create Sample objects and attach the sample file objects
+        project_sample_files = list(map(
+            self.sample_file_from_sample_path,
+            project_fastq_files))
+        project_samples = map(
+            _sample_from_name,
+            set(map(
+                _name_from_sample_file,
+                project_sample_files)))
+        for project_sample in project_samples:
+            project_sample.sample_files = list(filter(
+                lambda f: f.sample_name == project_sample.name,
+                project_sample_files
+            ))
+            yield project_sample
+
+    def sample_file_from_sample_path(self, sample_path):
+        file_name = os.path.basename(sample_path)
+        m = re.match(self.filename_regexp, file_name)
+        if not m or len(m.groups()) != 5:
+            raise FileNameParsingException("Could not parse information from file name '{}'".format(file_name))
+        sample_name = str(m.group(1))
+        sample_index = str(m.group(2))
+        lane_no = int(m.group(3))
+        is_index = (str(m.group(4)) == "I")
+        read_no = int(m.group(5))
+        return SampleFile(
+            sample_path,
+            sample_name=sample_name,
+            sample_index=sample_index,
+            lane_no=lane_no,
+            read_no=read_no,
+            is_index=is_index)
+

--- a/delivery/repositories/sample_repository.py
+++ b/delivery/repositories/sample_repository.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 
-from delivery.exceptions import FileNameParsingException
+from delivery.exceptions import ChecksumNotFoundException, FileNameParsingException
 from delivery.models.sample import Sample, SampleFile
 
 from delivery.services.file_system_service import FileSystemService
@@ -18,10 +18,10 @@ class RunfolderProjectBasedSampleRepository(object):
     def __init__(self, file_system_service=FileSystemService()):
         self.file_system_service = file_system_service
 
-    def get_samples(self, project):
-        return self._get_samples(project)
+    def get_samples(self, project, runfolder):
+        return self._get_samples(project, runfolder)
 
-    def _get_samples(self, project):
+    def _get_samples(self, project, runfolder):
 
         def _is_fastq_file(f):
             return re.match(self.filename_regexp, f) is not None
@@ -32,13 +32,16 @@ class RunfolderProjectBasedSampleRepository(object):
         def _sample_from_name(n):
             return Sample(n, project.name)
 
+        def _sample_file_from_path(p):
+            return self.sample_file_from_sample_path(p, runfolder)
+
         project_fastq_files = filter(
             _is_fastq_file,
             self.file_system_service.list_files_recursively(project.path))
 
         # create SampleFile objects from the paths, create Sample objects and attach the sample file objects
         project_sample_files = list(map(
-            self.sample_file_from_sample_path,
+            _sample_file_from_path,
             project_fastq_files))
         project_samples = map(
             _sample_from_name,
@@ -52,7 +55,16 @@ class RunfolderProjectBasedSampleRepository(object):
             ))
             yield project_sample
 
-    def sample_file_from_sample_path(self, sample_path):
+    def checksum_from_sample_path(self, sample_path, runfolder):
+        relative_path = self.file_system_service.relpath(
+            sample_path,
+            os.path.dirname(runfolder.path))
+        try:
+            return runfolder.checksums[relative_path]
+        except (KeyError, TypeError):
+            raise ChecksumNotFoundException("no pre-calculated checksum could be found for '{}'".format(relative_path))
+
+    def sample_file_from_sample_path(self, sample_path, runfolder):
         file_name = os.path.basename(sample_path)
         m = re.match(self.filename_regexp, file_name)
         if not m or len(m.groups()) != 5:
@@ -62,11 +74,18 @@ class RunfolderProjectBasedSampleRepository(object):
         lane_no = int(m.group(3))
         is_index = (str(m.group(4)) == "I")
         read_no = int(m.group(5))
+        try:
+            checksum = self.checksum_from_sample_path(sample_path, runfolder)
+        except ChecksumNotFoundException as e:
+            log.info(e)
+            checksum = None
+
         return SampleFile(
             sample_path,
             sample_name=sample_name,
             sample_index=sample_index,
             lane_no=lane_no,
             read_no=read_no,
-            is_index=is_index)
+            is_index=is_index,
+            checksum=checksum)
 

--- a/delivery/services/delivery_service.py
+++ b/delivery/services/delivery_service.py
@@ -90,7 +90,8 @@ class DeliveryService(object):
         return self.file_system_service.abspath(project_dir)
 
     def deliver_single_runfolder(self, runfolder_name, only_these_projects, force_delivery):
-        projects = list(self.runfolder_service.find_projects_on_runfolder(runfolder_name, only_these_projects))
+        runfolder = self.runfolder_service.find_runfolder(runfolder_name)
+        projects = list(self.runfolder_service.find_projects_on_runfolder(runfolder, only_these_projects))
         return self._start_staging_projects(projects, force_delivery)
 
     def _get_projects_to_deliver(self, projects, mode, batch_nbr):

--- a/delivery/services/file_system_service.py
+++ b/delivery/services/file_system_service.py
@@ -1,9 +1,6 @@
 
-import csv
 import os
 import logging
-
-from delivery.exceptions import ChecksumFileNotFoundException, SamplesheetNotFoundException
 
 log = logging.getLogger(__name__)
 
@@ -47,47 +44,6 @@ class FileSystemService(object):
     def list_files_recursively(base_path):
         for root, dirs, files in os.walk(base_path):
             yield from map(lambda f: os.path.join(root, f), files)
-
-    @staticmethod
-    def extract_samplesheet_data(samplesheet_file):
-
-        def _extract_samplesheet_data_section(filehandle):
-            return list(csv.DictReader(filehandle))
-
-        try:
-            with open(samplesheet_file, "r") as fh:
-                while not next(fh).startswith("[Data]"):
-                    pass
-                return _extract_samplesheet_data_section(fh)
-        except IOError as e:
-            raise SamplesheetNotFoundException(e)
-
-    @staticmethod
-    def parse_checksum_file(checksum_file):
-        file_checksums = {}
-        try:
-            with open(checksum_file) as chksumh:
-                for entry in chksumh:
-                    checksum, file_path = entry.split()
-                    file_checksums[file_path] = checksum
-        except IOError as e:
-            raise ChecksumFileNotFoundException("Checksum file '{}' could not be opened: {}".format(checksum_file, e))
-        return file_checksums
-
-    @staticmethod
-    def write_checksum_file(checksum_file, checksums):
-        with open(checksum_file, "w") as fh:
-            for file_path, checksum in checksums.items():
-                fh.write("{}  {}\n".format(checksum, file_path))
-
-    @staticmethod
-    def write_samplesheet_file(samplesheet_file, samplesheet_data):
-        header = samplesheet_data[0].keys()
-        with open(samplesheet_file, "w") as fh:
-            fh.write("[Data]\n")
-            writer = csv.DictWriter(fh, fieldnames=header)
-            writer.writeheader()
-            writer.writerows(samplesheet_data)
 
     @staticmethod
     def isdir(path):

--- a/delivery/services/file_system_service.py
+++ b/delivery/services/file_system_service.py
@@ -1,7 +1,9 @@
 
+import csv
 import os
-
 import logging
+
+from delivery.exceptions import ChecksumFileNotFoundException, SamplesheetNotFoundException
 
 log = logging.getLogger(__name__)
 
@@ -44,6 +46,47 @@ class FileSystemService(object):
     def list_files_recursively(self, base_path):
         for root, dirs, files in os.walk(base_path):
             yield from map(lambda f: os.path.join(root, f), files)
+
+    @staticmethod
+    def extract_samplesheet_data(samplesheet_file):
+
+        def _extract_samplesheet_data_section(filehandle):
+            return list(csv.DictReader(filehandle))
+
+        try:
+            with open(samplesheet_file, "r") as fh:
+                while not next(fh).startswith("[Data]"):
+                    pass
+                return _extract_samplesheet_data_section(fh)
+        except IOError as e:
+            raise SamplesheetNotFoundException(e)
+
+    @staticmethod
+    def parse_checksum_file(checksum_file):
+        file_checksums = {}
+        try:
+            with open(checksum_file) as chksumh:
+                for entry in chksumh:
+                    checksum, file_path = entry.split()
+                    file_checksums[file_path] = checksum
+        except IOError as e:
+            raise ChecksumFileNotFoundException("Checksum file '{}' could not be opened: {}".format(checksum_file, e))
+        return file_checksums
+
+    @staticmethod
+    def write_checksum_file(checksum_file, checksums):
+        with open(checksum_file, "w") as fh:
+            for checksum, file_path in checksums.items():
+                fh.write("{}  {}\n".format(checksum, file_path))
+
+    @staticmethod
+    def write_samplesheet_file(samplesheet_file, samplesheet_data):
+        header = samplesheet_data[0].keys()
+        with open(samplesheet_file, "w") as fh:
+            fh.write("[Data]\n")
+            writer = csv.DictWriter(fh, fieldnames=header)
+            writer.writeheader()
+            writer.writerows(samplesheet_data)
 
     @staticmethod
     def isdir(path):

--- a/delivery/services/file_system_service.py
+++ b/delivery/services/file_system_service.py
@@ -43,7 +43,8 @@ class FileSystemService(object):
         """
         return self.list_directories(base_path)
 
-    def list_files_recursively(self, base_path):
+    @staticmethod
+    def list_files_recursively(base_path):
         for root, dirs, files in os.walk(base_path):
             yield from map(lambda f: os.path.join(root, f), files)
 
@@ -76,7 +77,7 @@ class FileSystemService(object):
     @staticmethod
     def write_checksum_file(checksum_file, checksums):
         with open(checksum_file, "w") as fh:
-            for checksum, file_path in checksums.items():
+            for file_path, checksum in checksums.items():
                 fh.write("{}  {}\n".format(checksum, file_path))
 
     @staticmethod
@@ -124,14 +125,14 @@ class FileSystemService(object):
         """
         return os.path.abspath(path)
 
-    @staticmethod
-    def symlink(source, link_name):
+    def symlink(self, source, link_name):
         """
         Shadows os.symlink
         :param source: of link
         :param link_name: the name of the link to create
         :return: None
         """
+        self.makedirs(self.dirname(link_name), exist_ok=True)
         return os.symlink(source, link_name)
 
     @staticmethod
@@ -144,17 +145,21 @@ class FileSystemService(object):
         os.mkdir(path)
 
     @staticmethod
-    def makedirs(path):
+    def makedirs(path, **kwargs):
         """
         shadows os.makedirs
         :param path: to dir to create
         :return: None
         """
-        os.makedirs(path)
+        os.makedirs(path, **kwargs)
 
     @staticmethod
     def exists(path):
         return os.path.exists(path)
+
+    @staticmethod
+    def dirname(path):
+        return os.path.dirname(path)
 
     @staticmethod
     def rename(src, dst):

--- a/delivery/services/file_system_service.py
+++ b/delivery/services/file_system_service.py
@@ -41,6 +41,10 @@ class FileSystemService(object):
         """
         return self.list_directories(base_path)
 
+    def list_files_recursively(self, base_path):
+        for root, dirs, files in os.walk(base_path):
+            yield from map(lambda f: os.path.join(root, f), files)
+
     @staticmethod
     def isdir(path):
         """
@@ -108,3 +112,11 @@ class FileSystemService(object):
     @staticmethod
     def exists(path):
         return os.path.exists(path)
+
+    @staticmethod
+    def rename(src, dst):
+        return os.rename(src, dst)
+
+    @staticmethod
+    def relpath(path, start):
+        return os.path.relpath(path, start)

--- a/delivery/services/metadata_service.py
+++ b/delivery/services/metadata_service.py
@@ -61,5 +61,5 @@ class MetadataService(object):
     def hash_string(input_string, hasher_obj=None):
         if not hasher_obj:
             hasher_obj = MetadataService.get_hash_object()
-        hasher_obj.update(input_string.encode("utf-8"))
+        hasher_obj.update(input_string.encode())
         return hasher_obj.hexdigest()

--- a/delivery/services/metadata_service.py
+++ b/delivery/services/metadata_service.py
@@ -1,4 +1,5 @@
 import csv
+import hashlib
 import logging
 
 from delivery.exceptions import ChecksumFileNotFoundException, SamplesheetNotFoundException
@@ -51,3 +52,14 @@ class MetadataService(object):
             writer = csv.DictWriter(fh, fieldnames=header)
             writer.writeheader()
             writer.writerows(samplesheet_data)
+
+    @staticmethod
+    def get_hash_object():
+        return hashlib.md5()
+
+    @staticmethod
+    def hash_string(input_string, hasher_obj=None):
+        if not hasher_obj:
+            hasher_obj = MetadataService.get_hash_object()
+        hasher_obj.update(input_string.encode("utf-8"))
+        return hasher_obj.hexdigest()

--- a/delivery/services/metadata_service.py
+++ b/delivery/services/metadata_service.py
@@ -63,3 +63,11 @@ class MetadataService(object):
             hasher_obj = MetadataService.get_hash_object()
         hasher_obj.update(input_string.encode())
         return hasher_obj.hexdigest()
+
+    @staticmethod
+    def hash_file(input_file):
+        hasher_obj = MetadataService.get_hash_object()
+        with open(input_file, 'rb') as fh:
+            for line in fh:
+                hasher_obj.update(line)
+        return hasher_obj.hexdigest()

--- a/delivery/services/metadata_service.py
+++ b/delivery/services/metadata_service.py
@@ -32,7 +32,7 @@ class MetadataService(object):
         try:
             with open(checksum_file) as chksumh:
                 for entry in chksumh:
-                    checksum, file_path = entry.split(maxsplit=1)
+                    checksum, file_path = entry.strip().split(maxsplit=1)
                     file_checksums[file_path] = checksum
         except IOError as e:
             raise ChecksumFileNotFoundException("Checksum file '{}' could not be opened: {}".format(checksum_file, e))

--- a/delivery/services/metadata_service.py
+++ b/delivery/services/metadata_service.py
@@ -1,0 +1,53 @@
+import csv
+import logging
+
+from delivery.exceptions import ChecksumFileNotFoundException, SamplesheetNotFoundException
+
+log = logging.getLogger(__name__)
+
+
+class MetadataService(object):
+    """
+    Metadata service, used for reading and writing metadata files associated with the service.
+    """
+
+    @staticmethod
+    def extract_samplesheet_data(samplesheet_file):
+
+        def _extract_samplesheet_data_section(filehandle):
+            return list(csv.DictReader(filehandle))
+
+        try:
+            with open(samplesheet_file, "r") as fh:
+                while not next(fh).startswith("[Data]"):
+                    pass
+                return _extract_samplesheet_data_section(fh)
+        except IOError as e:
+            raise SamplesheetNotFoundException(e)
+
+    @staticmethod
+    def parse_checksum_file(checksum_file):
+        file_checksums = {}
+        try:
+            with open(checksum_file) as chksumh:
+                for entry in chksumh:
+                    checksum, file_path = entry.split(maxsplit=1)
+                    file_checksums[file_path] = checksum
+        except IOError as e:
+            raise ChecksumFileNotFoundException("Checksum file '{}' could not be opened: {}".format(checksum_file, e))
+        return file_checksums
+
+    @staticmethod
+    def write_checksum_file(checksum_file, checksums):
+        with open(checksum_file, "w") as fh:
+            for file_path, checksum in checksums.items():
+                fh.write("{}  {}\n".format(checksum, file_path))
+
+    @staticmethod
+    def write_samplesheet_file(samplesheet_file, samplesheet_data):
+        header = samplesheet_data[0].keys()
+        with open(samplesheet_file, "w") as fh:
+            fh.write("[Data]\n")
+            writer = csv.DictWriter(fh, fieldnames=header)
+            writer.writeheader()
+            writer.writerows(samplesheet_data)

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -5,6 +5,8 @@ import time
 
 from delivery.exceptions import ProjectAlreadyOrganisedException
 
+from delivery.models.project import RunfolderProject
+from delivery.models.runfolder import Runfolder
 from delivery.models.sample import Sample, SampleFile
 from delivery.services.file_system_service import FileSystemService
 
@@ -18,7 +20,7 @@ class OrganiseService(object):
     started, and their status monitored by querying the underlying database for their status.
     """
 
-    def __init__(self, runfolder_service, sample_repository, file_system_service=FileSystemService()):
+    def __init__(self, runfolder_service, file_system_service=FileSystemService()):
         """
         Instantiate a new StagingService
         :param staging_dir: the directory to which files/dirs should be staged
@@ -31,21 +33,34 @@ class OrganiseService(object):
         :param session_factory: a factory method which can produce new sqlalchemy Session instances
         """
         self.runfolder_service = runfolder_service
-        self.sample_repository = sample_repository
         self.file_system_service = file_system_service
 
     def organise_runfolder(self, runfolder_id, lanes, projects, force):
+        runfolder = self.runfolder_service.find_runfolder(runfolder_id)
         projects_on_runfolder = self.runfolder_service.find_projects_on_runfolder(
-            runfolder_name=runfolder_id,
+            runfolder,
             only_these_projects=projects)
+        organised_projects = []
         for project in projects_on_runfolder:
             try:
-                self.organise_project(project, lanes, force)
+                organised_project = self.organise_project(
+                    runfolder,
+                    project,
+                    lanes,
+                    force)
+                self.runfolder_service.dump_project_checksums(organised_project)
+                self.runfolder_service.dump_project_samplesheet(runfolder, organised_project)
+                organised_projects.append(organised_project)
             except ProjectAlreadyOrganisedException as e:
                 log.info(e)
                 log.info("no re-organisation of {} was attempted".format(project.name))
+                raise
+        return Runfolder(
+            runfolder.name,
+            runfolder.path,
+            projects=organised_projects)
 
-    def organise_project(self, project, lanes, force):
+    def organise_project(self, runfolder, project, lanes, force):
         organised_project_path = os.path.join(project.runfolder_path, "Projects", project.name)
 
         # handle the case when the organised path already exists
@@ -60,10 +75,21 @@ class OrganiseService(object):
             self.file_system_service.rename(existing_path, backup_path)
 
         # symlink the samples
-        self.file_system_service.makedirs(organised_project_path)
-        samples = self.sample_repository.get_samples(project)
-        for sample in samples:
-            self.organise_sample(sample, organised_project_path, lanes)
+        organised_project_runfolder_path = os.path.join(organised_project_path, runfolder.name)
+        self.file_system_service.makedirs(organised_project_runfolder_path)
+        organised_samples = []
+        for sample in project.samples:
+            organised_samples.append(
+                self.organise_sample(
+                    sample,
+                    organised_project_runfolder_path,
+                    lanes))
+        return RunfolderProject(
+            project.name,
+            organised_project_path,
+            runfolder.path,
+            runfolder.name,
+            samples=organised_samples)
 
     def organise_sample(self, sample, organised_project_path, lanes):
 
@@ -71,7 +97,7 @@ class OrganiseService(object):
             return not lanes or f.lane_no in lanes
 
         # symlink each sample in its own directory
-        organised_sample_path = os.path.join(organised_project_path, "Sample_{}".format(sample.name))
+        organised_sample_path = os.path.join(organised_project_path, sample.name)
 
         # filter the files if lanes should be excluded
         sample_files_to_symlink = list(filter(_include_sample_file, sample.sample_files))
@@ -79,20 +105,21 @@ class OrganiseService(object):
             self.file_system_service.makedirs(organised_sample_path)
 
         # symlink the sample files using relative paths
-        organised_sample = Sample(
-            name=sample.name,
-            project_name=sample.project_name,
-            sample_files=[])
+        organised_sample_files = []
         for sample_file in sample_files_to_symlink:
             link_name = os.path.join(organised_sample_path, sample_file.file_name)
             relative_path = self.file_system_service.relpath(sample_file.sample_path, os.path.dirname(link_name))
             self.file_system_service.symlink(relative_path, link_name)
-            organised_sample.sample_files.append(
+            organised_sample_files.append(
                 SampleFile(
                     link_name,
                     sample_name=sample_file.sample_name,
                     sample_index=sample_file.sample_index,
                     lane_no=sample_file.lane_no,
                     read_no=sample_file.read_no,
-                    is_index=sample_file.is_index))
-        return organised_sample
+                    is_index=sample_file.is_index,
+                    checksum=sample_file.checksum))
+        return Sample(
+            name=sample.name,
+            project_name=sample.project_name,
+            sample_files=organised_sample_files)

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -64,7 +64,7 @@ class OrganiseService(object):
 
     def check_previously_organised_project(self, project, organised_projects_path, force):
         organised_project_path = os.path.join(organised_projects_path, project.name)
-        if os.path.exists(organised_project_path):
+        if self.file_system_service.exists(organised_project_path):
             msg = "Organised project path '{}' already exists".format(organised_project_path)
             if not force:
                 raise ProjectAlreadyOrganisedException(msg)

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -60,7 +60,8 @@ class OrganiseService(object):
         return Runfolder(
             runfolder.name,
             runfolder.path,
-            projects=organised_projects)
+            projects=organised_projects,
+            checksums=runfolder.checksums)
 
     def check_previously_organised_project(self, project, organised_projects_path, force):
         organised_project_path = os.path.join(organised_projects_path, project.name)

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -44,9 +44,8 @@ class OrganiseService(object):
         """
         # retrieve a runfolder object and project objects to be organised
         runfolder = self.runfolder_service.find_runfolder(runfolder_id)
-        projects_on_runfolder = self.runfolder_service.find_projects_on_runfolder(
-            runfolder,
-            only_these_projects=projects)
+        projects_on_runfolder = list(
+            self.runfolder_service.find_projects_on_runfolder(runfolder, only_these_projects=projects))
 
         # handle previously organised projects
         organised_projects_path = os.path.join(runfolder.path, "Projects")

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -6,7 +6,7 @@ import time
 from delivery.exceptions import ProjectAlreadyOrganisedException
 
 from delivery.models.project import RunfolderProject
-from delivery.models.runfolder import Runfolder
+from delivery.models.runfolder import Runfolder, RunfolderFile
 from delivery.models.sample import Sample, SampleFile
 from delivery.services.file_system_service import FileSystemService
 
@@ -101,43 +101,53 @@ class OrganiseService(object):
                     sample,
                     organised_project_runfolder_path,
                     lanes))
+        # symlink the project files
+        organised_project_files = []
+        if project.project_files:
+            project_file_base = self.file_system_service.dirname(project.project_files[0].file_path)
+            for project_file in project.project_files:
+                organised_project_files.append(
+                    self.organise_project_file(
+                        project_file,
+                        organised_project_runfolder_path,
+                        project_file_base=project_file_base))
         organised_project = RunfolderProject(
             project.name,
             organised_project_path,
             runfolder.path,
             runfolder.name,
             samples=organised_samples)
-        self.symlink_project_report(project, organised_project)
+        organised_project_files.append(
+            self.runfolder_service.dump_project_samplesheet(
+                runfolder,
+                organised_project)
+        )
+        organised_project.project_files = organised_project_files
         self.runfolder_service.dump_project_checksums(organised_project)
-        self.runfolder_service.dump_project_samplesheet(runfolder, organised_project)
+
         return organised_project
 
-    def symlink_project_report(self, project, organised_project):
+    def organise_project_file(self, project_file, organised_project_path, project_file_base=None):
         """
         Find and symlink the project report to the organised project directory.
 
         :param project: a Project instance representing the project before organisation
         :param organised_project: a Project instance representing the project after organisation
         """
-        project_report_base, project_report_files = self.runfolder_service.get_project_report_files(project)
+        project_file_base = project_file_base or self.file_system_service.dirname(project_file.file_path)
 
-        def _link_name(target_file):
-            return os.path.join(
-                organised_project.path,
-                self.file_system_service.relpath(
-                    target_file,
-                    project_report_base))
-
-        def _link_path(target_file, link_name):
-            return self.file_system_service.relpath(
-                target_file,
-                self.file_system_service.dirname(link_name)
-            )
-
-        for project_report_file in project_report_files:
-            link_name = _link_name(project_report_file)
-            link_path = _link_path(project_report_file, link_name)
-            self.file_system_service.symlink(link_path, link_name)
+        # the full path to the symlink
+        link_name = os.path.join(
+            organised_project_path,
+            self.file_system_service.relpath(
+                project_file.file_path,
+                project_file_base))
+        # the relative path from the symlink to the original file
+        link_path = self.file_system_service.relpath(
+            project_file.file_path,
+            self.file_system_service.dirname(link_name))
+        self.file_system_service.symlink(link_path, link_name)
+        return RunfolderFile(link_name, file_checksum=project_file.checksum)
 
     def organise_sample(self, sample, organised_project_path, lanes):
         """
@@ -186,7 +196,7 @@ class OrganiseService(object):
 
         # create the symlink in the supplied directory and relative to the file's original location
         link_name = os.path.join(organised_sample_path, sample_file.file_name)
-        relative_path = self.file_system_service.relpath(sample_file.sample_path, organised_sample_path)
+        relative_path = self.file_system_service.relpath(sample_file.file_path, organised_sample_path)
         self.file_system_service.symlink(relative_path, link_name)
         return SampleFile(
             link_name,

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -1,0 +1,98 @@
+
+import logging
+import os
+import time
+
+from delivery.exceptions import ProjectAlreadyOrganisedException
+
+from delivery.models.sample import Sample, SampleFile
+from delivery.services.file_system_service import FileSystemService
+
+log = logging.getLogger(__name__)
+
+
+class OrganiseService(object):
+    """
+    Starting in this context means copying a directory or file to a separate directory before delivering it.
+    This service handles that in a asynchronous way. Copying operations (right nwo powered by rsync) can be
+    started, and their status monitored by querying the underlying database for their status.
+    """
+
+    def __init__(self, runfolder_service, sample_repository, file_system_service=FileSystemService()):
+        """
+        Instantiate a new StagingService
+        :param staging_dir: the directory to which files/dirs should be staged
+        :param external_program_service: a instance of ExternalProgramService
+        :param staging_repo: a instance of DatabaseBasedStagingRepository
+        :param runfolder_repo: a instance of FileSystemBasedRunfolderRepository
+        :param project_dir_repo: a instance of GeneralProjectRepository
+        :param project_links_directory: a path to a directory where links will be created temporarily
+                                        before they are rsynced into staging (for batched deliveries etc)
+        :param session_factory: a factory method which can produce new sqlalchemy Session instances
+        """
+        self.runfolder_service = runfolder_service
+        self.sample_repository = sample_repository
+        self.file_system_service = file_system_service
+
+    def organise_runfolder(self, runfolder_id, lanes, projects, force):
+        projects_on_runfolder = self.runfolder_service.find_projects_on_runfolder(
+            runfolder_name=runfolder_id,
+            only_these_projects=projects)
+        for project in projects_on_runfolder:
+            try:
+                self.organise_project(project, lanes, force)
+            except ProjectAlreadyOrganisedException as e:
+                log.info(e)
+                log.info("no re-organisation of {} was attempted".format(project.name))
+
+    def organise_project(self, project, lanes, force):
+        organised_project_path = os.path.join(project.runfolder_path, "Projects", project.name)
+
+        # handle the case when the organised path already exists
+        if self.file_system_service.exists(organised_project_path):
+            msg = "Organised project path '{}' already exists".format(organised_project_path)
+            if not force:
+                raise ProjectAlreadyOrganisedException(msg)
+            existing_path = os.path.dirname(organised_project_path)
+            backup_path = "{}.{}".format(existing_path, str(time.time()))
+            log.info(msg)
+            log.info("existing path '{}' will be moved to '{}'".format(existing_path, backup_path))
+            self.file_system_service.rename(existing_path, backup_path)
+
+        # symlink the samples
+        self.file_system_service.makedirs(organised_project_path)
+        samples = self.sample_repository.get_samples(project)
+        for sample in samples:
+            self.organise_sample(sample, organised_project_path, lanes)
+
+    def organise_sample(self, sample, organised_project_path, lanes):
+
+        def _include_sample_file(f):
+            return not lanes or f.lane_no in lanes
+
+        # symlink each sample in its own directory
+        organised_sample_path = os.path.join(organised_project_path, "Sample_{}".format(sample.name))
+
+        # filter the files if lanes should be excluded
+        sample_files_to_symlink = list(filter(_include_sample_file, sample.sample_files))
+        if sample_files_to_symlink:
+            self.file_system_service.makedirs(organised_sample_path)
+
+        # symlink the sample files using relative paths
+        organised_sample = Sample(
+            name=sample.name,
+            project_name=sample.project_name,
+            sample_files=[])
+        for sample_file in sample_files_to_symlink:
+            link_name = os.path.join(organised_sample_path, sample_file.file_name)
+            relative_path = self.file_system_service.relpath(sample_file.sample_path, os.path.dirname(link_name))
+            self.file_system_service.symlink(relative_path, link_name)
+            organised_sample.sample_files.append(
+                SampleFile(
+                    link_name,
+                    sample_name=sample_file.sample_name,
+                    sample_index=sample_file.sample_index,
+                    lane_no=sample_file.lane_no,
+                    read_no=sample_file.read_no,
+                    is_index=sample_file.is_index))
+        return organised_sample

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -39,32 +39,47 @@ class OrganiseService(object):
         :param lanes: if not None, only samples on any of the specified lanes will be organised
         :param projects: if not None, only projects in this list will be organised
         :param force: if True, a previously organised project will be renamed with a unique suffix
-        :raises ProjectAlreadyOrganisedException: if project has already been organised and force is False
+        :raises ProjectAlreadyOrganisedException: if a project has already been organised and force is False
         :return: a Runfolder instance representing the runfolder after organisation
         """
+        # retrieve a runfolder object and project objects to be organised
         runfolder = self.runfolder_service.find_runfolder(runfolder_id)
         projects_on_runfolder = self.runfolder_service.find_projects_on_runfolder(
             runfolder,
             only_these_projects=projects)
+
+        # handle previously organised projects
+        organised_projects_path = os.path.join(runfolder.path, "Projects")
+        for project in projects_on_runfolder:
+            self.check_previously_organised_project(project, organised_projects_path, force)
+
+        # organise the projects and return a new Runfolder instance
         organised_projects = []
         for project in projects_on_runfolder:
-            try:
-                organised_projects.append(
-                    self.organise_project(
-                        runfolder,
-                        project,
-                        lanes,
-                        force))
-            except ProjectAlreadyOrganisedException as e:
-                log.info(e)
-                log.info("no re-organisation of {} was attempted".format(project.name))
-                raise
+            organised_projects.append(self.organise_project(runfolder, project, organised_projects_path, lanes))
+
         return Runfolder(
             runfolder.name,
             runfolder.path,
             projects=organised_projects)
 
-    def organise_project(self, runfolder, project, lanes, force):
+    def check_previously_organised_project(self, project, organised_projects_path, force):
+        organised_project_path = os.path.join(organised_projects_path, project.name)
+        if os.path.exists(organised_project_path):
+            msg = "Organised project path '{}' already exists".format(organised_project_path)
+            if not force:
+                raise ProjectAlreadyOrganisedException(msg)
+            organised_projects_backup_path = "{}.bak".format(organised_projects_path)
+            backup_path = os.path.join(
+                organised_projects_backup_path,
+                "{}.{}".format(project.name, str(time.time())))
+            log.info(msg)
+            log.info("existing path '{}' will be moved to '{}'".format(organised_project_path, backup_path))
+            if not self.file_system_service.exists(organised_projects_backup_path):
+                self.file_system_service.mkdir(organised_projects_backup_path)
+            self.file_system_service.rename(organised_project_path, backup_path)
+
+    def organise_project(self, runfolder, project, organised_projects_path, lanes):
         """
         Organise a project on a runfolder into its own directory and into a standard structure. If the project has
         already been organised, a ProjectAlreadyOrganisedException will be raised, unless force is True. If force is
@@ -77,22 +92,9 @@ class OrganiseService(object):
         :raises ProjectAlreadyOrganisedException: if project has already been organised and force is False
         :return: a Project instance representing the project after organisation
         """
-        organised_project_path = os.path.join(project.runfolder_path, "Projects", project.name)
-
-        # handle the case when the organised path already exists
-        if self.file_system_service.exists(organised_project_path):
-            msg = "Organised project path '{}' already exists".format(organised_project_path)
-            if not force:
-                raise ProjectAlreadyOrganisedException(msg)
-            existing_path = os.path.dirname(organised_project_path)
-            backup_path = "{}.{}".format(existing_path, str(time.time()))
-            log.info(msg)
-            log.info("existing path '{}' will be moved to '{}'".format(existing_path, backup_path))
-            self.file_system_service.rename(existing_path, backup_path)
-
         # symlink the samples
+        organised_project_path = os.path.join(organised_projects_path, project.name)
         organised_project_runfolder_path = os.path.join(organised_project_path, runfolder.name)
-        self.file_system_service.makedirs(organised_project_runfolder_path)
         organised_samples = []
         for sample in project.samples:
             organised_samples.append(
@@ -151,36 +153,47 @@ class OrganiseService(object):
         :return: a new Sample instance representing the sample after organisation
         """
 
-        def _include_sample_file(f):
-            return not lanes or f.lane_no in lanes
-
         # symlink each sample in its own directory
         organised_sample_path = os.path.join(organised_project_path, sample.sample_id)
 
-        # filter the files if lanes should be excluded
-        sample_files_to_symlink = list(filter(_include_sample_file, sample.sample_files))
-        if sample_files_to_symlink:
-            self.file_system_service.makedirs(organised_sample_path)
-
         # symlink the sample files using relative paths
         organised_sample_files = []
-        for sample_file in sample_files_to_symlink:
-            link_name = os.path.join(organised_sample_path, sample_file.file_name)
-            relative_path = self.file_system_service.relpath(
-                sample_file.sample_path,
-                self.file_system_service.dirname(link_name))
-            self.file_system_service.symlink(relative_path, link_name)
-            organised_sample_files.append(
-                SampleFile(
-                    link_name,
-                    sample_name=sample_file.sample_name,
-                    sample_index=sample_file.sample_index,
-                    lane_no=sample_file.lane_no,
-                    read_no=sample_file.read_no,
-                    is_index=sample_file.is_index,
-                    checksum=sample_file.checksum))
+        for sample_file in sample.sample_files:
+            organised_sample_files.append(self.organise_sample_file(sample_file, organised_sample_path, lanes))
+
+        # clean up the list of sample files by removing None elements
+        organised_sample_files = list(filter(None, organised_sample_files))
+
         return Sample(
             name=sample.name,
             project_name=sample.project_name,
             sample_id=sample.sample_id,
             sample_files=organised_sample_files)
+
+    def organise_sample_file(self, sample_file, organised_sample_path, lanes):
+        """
+        Organise a sample file by creating a relative symlink in the supplied directory, pointing back to the supplied
+        SampleFile's original file path. The Sample file can be excluded from organisation based on the lane it was
+        derived from. The supplied directory will be created if it doesn't exist.
+
+        :param sample_file: a SampleFile instance representing the sample file to be organised
+        :param organised_sample_path: the path to the organised sample directory under which to place the symlink
+        :param lanes: if not None, only sample files derived from any of the specified lanes will be organised
+        :return: a new SampleFile instance representing the sample file after organisation
+        """
+        # skip if the sample file data is derived from a lane that shouldn't be included
+        if lanes and sample_file.lane_no not in lanes:
+            return None
+
+        # create the symlink in the supplied directory and relative to the file's original location
+        link_name = os.path.join(organised_sample_path, sample_file.file_name)
+        relative_path = self.file_system_service.relpath(sample_file.sample_path, organised_sample_path)
+        self.file_system_service.symlink(relative_path, link_name)
+        return SampleFile(
+            link_name,
+            sample_name=sample_file.sample_name,
+            sample_index=sample_file.sample_index,
+            lane_no=sample_file.lane_no,
+            read_no=sample_file.read_no,
+            is_index=sample_file.is_index,
+            checksum=sample_file.checksum)

--- a/delivery/services/runfolder_service.py
+++ b/delivery/services/runfolder_service.py
@@ -6,6 +6,7 @@ from delivery.exceptions import RunfolderNotFoundException, ProjectNotFoundExcep
 
 log = logging.getLogger(__name__)
 
+
 class RunfolderService(object):
 
     def __init__(self, runfolder_repo):

--- a/delivery/services/runfolder_service.py
+++ b/delivery/services/runfolder_service.py
@@ -26,8 +26,7 @@ class RunfolderService(object):
         projects_on_runfolder_set = set(projects_on_runfolder)
         return projects_to_stage_set.issubset(projects_on_runfolder_set)
 
-    def find_projects_on_runfolder(self, runfolder_name, only_these_projects=None):
-        runfolder = self.find_runfolder(runfolder_name)
+    def find_projects_on_runfolder(self, runfolder, only_these_projects=None):
 
         names_of_project_on_runfolder = list(map(lambda x: x.name, runfolder.projects))
 
@@ -49,3 +48,9 @@ class RunfolderService(object):
 
     def find_runfolders_for_project(self, project_name):
         return self.runfolder_repo.get_project(project_name=project_name)
+
+    def dump_project_checksums(self, project):
+        return self.runfolder_repo.dump_project_checksums(project)
+
+    def dump_project_samplesheet(self, runfolder, project):
+        return self.runfolder_repo.dump_project_samplesheet(runfolder, project)

--- a/delivery/services/runfolder_service.py
+++ b/delivery/services/runfolder_service.py
@@ -54,3 +54,6 @@ class RunfolderService(object):
 
     def dump_project_samplesheet(self, runfolder, project):
         return self.runfolder_repo.dump_project_samplesheet(runfolder, project)
+
+    def get_project_report_files(self, project):
+        return self.runfolder_repo.get_project_report_files(project)

--- a/delivery/services/runfolder_service.py
+++ b/delivery/services/runfolder_service.py
@@ -74,7 +74,7 @@ class RunfolderService(object):
         """
         return self.runfolder_repo.dump_project_samplesheet(runfolder, project)
 
-    def get_project_report_files(self, project):
+    def get_project_report_files(self, runfolder, project):
         """
         Calls the `FileSystemBasedUnorganisedRunfolderRepository` instance associated with this service to collect
         paths to report files relevant to the supplied project.
@@ -84,4 +84,4 @@ class RunfolderService(object):
         :raises NotImplementedError: if the runfolder repo instance is not a
         `FileSystemBasedUnorganisedRunfolderRepository`
         """
-        return self.runfolder_repo.get_project_report_files(project)
+        return self.runfolder_repo.get_project_report_files(runfolder, project)

--- a/delivery/services/runfolder_service.py
+++ b/delivery/services/runfolder_service.py
@@ -50,10 +50,38 @@ class RunfolderService(object):
         return self.runfolder_repo.get_project(project_name=project_name)
 
     def dump_project_checksums(self, project):
+        """
+        Calls the `FileSystemBasedUnorganisedRunfolderRepository` instance associated with this service to dump out
+        checksums for files relevant to the supplied project to a file under the project path.
+
+        :param project: an instance of Project
+        :return: the path to the created checksum file
+        :raises NotImplementedError: if the runfolder repo instance is not a
+        `FileSystemBasedUnorganisedRunfolderRepository`
+        """
         return self.runfolder_repo.dump_project_checksums(project)
 
     def dump_project_samplesheet(self, runfolder, project):
+        """
+        Calls the `FileSystemBasedUnorganisedRunfolderRepository` instance associated with this service to write a
+        samplesheet only including the supplied project.
+
+        :param runfolder: an instance of Runfolder
+        :param project: an instance of Project
+        :return: the path to the created samplesheet file
+        :raises NotImplementedError: if the runfolder repo instance is not a
+        `FileSystemBasedUnorganisedRunfolderRepository`
+        """
         return self.runfolder_repo.dump_project_samplesheet(runfolder, project)
 
     def get_project_report_files(self, project):
+        """
+        Calls the `FileSystemBasedUnorganisedRunfolderRepository` instance associated with this service to collect
+        paths to report files relevant to the supplied project.
+
+        :param project: an instance of Project
+        :return: a tuple with the path to the directory containing the report and a list of paths to the report files
+        :raises NotImplementedError: if the runfolder repo instance is not a
+        `FileSystemBasedUnorganisedRunfolderRepository`
+        """
         return self.runfolder_repo.get_project_report_files(project)

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -69,16 +69,14 @@ class TestIntegration(AsyncHTTPTestCase):
             with open(file_path, 'wb') as f:
                 f.write(os.urandom(1024))
 
-        report_type = _toggle()
         os.makedirs(runfolder.path, exist_ok=True)
         for project in runfolder.projects:
             os.makedirs(project.path)
             for sample in project.samples:
                 for sample_file in sample.sample_files:
-                    _touch_file(sample_file.sample_path)
-            report_dir, report_files = project_report_files(project, multiqc_report=next(report_type))
-            for report_file in report_files:
-                _touch_file(report_file)
+                    _touch_file(sample_file.file_path)
+            for report_file in project.project_files:
+                _touch_file(report_file.file_path)
 
         checksum_file = os.path.join(runfolder.path, "MD5", "checksums.md5")
         os.mkdir(os.path.dirname(checksum_file))
@@ -149,44 +147,45 @@ class TestIntegration(AsyncHTTPTestCase):
                 sorted(response_json["projects"]))
 
             for project in runfolder.projects:
-                organised_path = os.path.join(runfolder.path, "Projects", project.name)
+                organised_path = os.path.join(runfolder.path, "Projects", project.name, runfolder.name)
                 self.assertTrue(os.path.exists(organised_path))
-                for f in "SampleSheet.csv", "checksums.md5":
-                    self.assertTrue(os.path.exists(os.path.join(organised_path, f)))
-                report_files = [
-                    os.path.join(organised_path, l) for l in (
-                        "report.html",
-                        "{}_multiqc_report.html".format(project.name))]
-                if os.path.exists(report_files[0]):
+                checksum_file = os.path.join(organised_path, "checksums.md5")
+                samplesheet_file = os.path.join(organised_path, "SampleSheet.csv")
+                for f in (checksum_file, samplesheet_file):
+                    self.assertTrue(os.path.exists(f))
+
+                checksums = MetadataService.parse_checksum_file(checksum_file)
+
+                def _verify_checksum(file_path, expected_checksum):
+                    self.assertIn(file_path, checksums)
+                    self.assertEqual(checksums[file_path], expected_checksum)
+
+                _verify_checksum(
+                    os.path.join(
+                        runfolder.name,
+                        os.path.basename(samplesheet_file)),
+                    MetadataService.hash_file(samplesheet_file))
+
+                project_file_base = os.path.dirname(project.project_files[0].file_path)
+                for project_file in project.project_files:
+                    relative_path = os.path.relpath(project_file.file_path, project_file_base)
+                    organised_project_file_path = os.path.join(organised_path, relative_path)
                     self.assertTrue(
                         os.path.samefile(
-                            os.path.join(
-                                runfolder.path,
-                                "Summary",
-                                project.name,
-                                os.path.basename(report_files[0])),
-                            report_files[0]))
-                elif os.path.exists(report_files[1]):
-                    self.assertTrue(
-                        os.path.samefile(
-                            os.path.join(
-                                project.path,
-                                os.path.basename(report_files[1])),
-                            report_files[1]))
-                else:
-                    raise AssertionError("Report files not properly linked")
-                self.assertTrue(
-                    any(
-                        map(
-                            lambda l: os.path.exists(os.path.join(organised_path, l)),
-                            ["report.html", "{}_multiqc_report.html".format(project.name)])))
+                            organised_project_file_path,
+                            project_file.file_path))
+                    _verify_checksum(os.path.join(runfolder.name, relative_path), project_file.checksum)
                 for sample in project.samples:
-                    sample_path = os.path.join(organised_path, runfolder.name, sample.sample_id)
+                    sample_path = os.path.join(organised_path, sample.sample_id)
                     self.assertTrue(os.path.exists(sample_path))
                     for sample_file in sample.sample_files:
                         organised_file_path = os.path.join(sample_path, sample_file.file_name)
                         self.assertTrue(os.path.exists(organised_file_path))
-                        self.assertTrue(os.path.samefile(sample_file.sample_path, organised_file_path))
+                        self.assertTrue(os.path.samefile(sample_file.file_path, organised_file_path))
+                        relative_file_path = os.path.join(
+                            runfolder.name,
+                            os.path.relpath(organised_file_path, organised_path))
+                        _verify_checksum(relative_file_path, sample_file.checksum)
 
     def test_can_stage_and_delivery_runfolder(self):
         # Note that this is a test which skips mover (since to_outbox is not expected to be installed on the system

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from mock import MagicMock
 from delivery.models.project import RunfolderProject
 from delivery.models.runfolder import Runfolder
 from delivery.models.sample import SampleFile, Sample
+from delivery.services.metadata_service import MetadataService
 
 
 class MockIOLoop():
@@ -39,6 +40,12 @@ def mock_file_system_service(directories, projects, fastq_files=None):
     mock_file_system_service_instance.find_project_directories.return_value = projects
     mock_file_system_service_instance.list_files_recursively.return_value = fastq_files or []
     return mock_file_system_service_instance
+
+
+def mock_metadata_service(checksums=None):
+    mock_metadata_service_instance = MagicMock(spec=MetadataService)
+    mock_metadata_service_instance.parse_checksum_file.return_value = checksums or {}
+    return mock_metadata_service_instance
 
 
 def _item_generator(prefix=None, suffix=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,14 @@
 
+import csv
+import os
 import time
-import random
+from collections import OrderedDict
 
 from mock import MagicMock
 
 from delivery.models.project import RunfolderProject
 from delivery.models.runfolder import Runfolder
-from delivery.services.external_program_service import ExecutionResult, Execution
+from delivery.models.sample import SampleFile, Sample
 
 
 class MockIOLoop():
@@ -38,6 +40,191 @@ def mock_file_system_service(directories, projects, fastq_files=None):
     mock_file_system_service_instance.list_files_recursively.return_value = fastq_files or []
     return mock_file_system_service_instance
 
+
+def _item_generator(prefix=None, suffix=None):
+    nxt = 1
+    while True:
+        yield "".join([prefix or "", str(nxt), suffix or ""])
+        nxt += 1
+
+
+def sample_name_generator():
+    yield from _item_generator(prefix="Sample_")
+
+
+def sample_index_generator():
+    yield from _item_generator(prefix="S")
+
+
+def lane_generator():
+    yield from _item_generator()
+
+
+def project_sample(project, sample_name, sample_index, lane_no, subdir=False):
+    sample_files = []
+    if subdir:
+        sample_dir = os.path.join(project.path, sample_name)
+    else:
+        sample_dir = project.path
+    for is_index in [False, True]:
+        for read_no in [1, 2]:
+            sample_path = os.path.join(
+                sample_dir,
+                "{}_{}_L00{}_{}{}_001.fastq.gz".format(
+                    sample_name,
+                    sample_index,
+                    str(lane_no),
+                    "I" if is_index else "R",
+                    str(read_no)))
+            sample_files.append(
+                SampleFile(
+                    sample_path=sample_path,
+                    sample_name=sample_name,
+                    sample_index=sample_index,
+                    lane_no=lane_no,
+                    read_no=read_no,
+                    is_index=is_index,
+                    checksum="checksum-for-{}".format(sample_path)))
+    return Sample(
+        name=sample_name,
+        project_name=project.name,
+        sample_files=sample_files
+    )
+
+
+def runfolder_project(
+        runfolder,
+        project_name="ABC_123",
+        sample_indexes=sample_index_generator(),
+        lane_numbers=lane_generator(),
+        project_root="Unaligned"):
+    project = RunfolderProject(
+        name=project_name,
+        path=os.path.join(runfolder.path, project_root, project_name),
+        runfolder_path=runfolder.path,
+        runfolder_name=runfolder.name
+    )
+
+    sample_names = sample_name_generator()
+
+    # a straight-forward sample with files on one lane
+    lane_number = next(lane_numbers)
+    samples = [project_sample(project, next(sample_names), next(sample_indexes), lane_number)]
+
+    # a sample with files on two lanes
+    sample_name = next(sample_names)
+    sample_index = next(sample_indexes)
+    sample = project_sample(project, sample_name, sample_index, lane_number)
+    lane_number = next(lane_numbers)
+    t_sample = project_sample(project, sample_name, sample_index, lane_number)
+    sample.sample_files.extend(t_sample.sample_files)
+    samples.append(sample)
+
+    # a sample with two preps on two lanes and sample files in subdirectories
+    t_samples = [
+        project_sample(
+            project,
+            sample_name="Sample_3",
+            sample_index=si,
+            lane_no=l,
+            subdir=True)
+        for si in [next(sample_indexes), next(sample_indexes)] for l in [next(lane_numbers), next(lane_numbers)]]
+    sample = t_samples[0]
+    sample.sample_files = [f for s in t_samples for f in s.sample_files]
+    samples.append(sample)
+
+    project.samples = samples
+    return project
+
+
+def unorganised_runfolder(name="180124_A00181_0019_BH72M5DMXX", root_path="/foo"):
+    sample_indexes = sample_index_generator()
+    lane_numbers = lane_generator()
+    runfolder = Runfolder(name=name, path=os.path.join(root_path, name))
+    runfolder.projects = [
+        runfolder_project(
+            runfolder,
+            project_name=p,
+            sample_indexes=sample_indexes,
+            lane_numbers=lane_numbers) for p in fake_projects]
+    checksums = {}
+    for project in runfolder.projects:
+        for sample in project.samples:
+            for sample_file in sample.sample_files:
+                checksums[sample_file.checksum] = os.path.relpath(
+                    sample_file.sample_path,
+                    os.path.dirname(runfolder.path))
+    runfolder.checksums = checksums
+    return runfolder
+
+
+def samplesheet_data_for_runfolder(runfolder):
+    samplesheet_data_headers = [
+        "Lane",
+        "Sample_ID",
+        "Sample_Name",
+        "Sample_Plate",
+        "Sample_Well",
+        "index",
+        "Sample_Project",
+        "Description"
+    ]
+    samplesheet_data = []
+    for project in runfolder.projects:
+        for sample in project.samples:
+            for sample_file in sample.sample_files:
+                if sample_file.read_no == 1 and not sample_file.is_index:
+                    samplesheet_data.append(
+                        OrderedDict(zip(
+                            samplesheet_data_headers,
+                            [
+                                str(sample_file.lane_no),
+                                sample_file.sample_id,
+                                sample_file.sample_name,
+                                str(),
+                                str(),
+                                "index_seq_{}".format(sample_file.sample_index),
+                                project.name,
+                                "PROJECT:{};SAMPLE:{};LANE:{};INDEX:{}".format(
+                                    project.name,
+                                    sample.name,
+                                    str(sample_file.lane_no),
+                                    sample_file.sample_index)])))
+    return samplesheet_data
+
+
+def samplesheet_file_from_runfolder(runfolder):
+    header_stuff = """[Header],,,,,,,,
+IEMFileVersion,4,,,,,,,
+Experiment Name,Hiseq-2500-single-index,,,,,,,
+Date,02/26/2019,,,,,,,
+Workflow,Resequencing,,,,,,,
+Application,Human Genome Resequencing,,,,,,,
+Assay,TruSeq LT,,,,,,,
+Description,,,,,,,,
+Chemistry,Default,,,,,,,
+,,,,,,,,
+[Reads],,,,,,,,
+50,,,,,,,,
+50,,,,,,,,
+,,,,,,,,
+[Settings],,,,,,,,
+FlagPCRDuplicates,1,,,,,,,
+Adapter,,,,,,,,
+AdapterRead2,,,,,,,,
+,,,,,,,,
+[Data],,,,,,,,
+"""
+    samplesheet_data = samplesheet_data_for_runfolder(runfolder)
+    samplesheet_file = os.path.join(runfolder.path, "SampleSheet.csv")
+    with open(samplesheet_file, "w") as fh:
+        fh.write(header_stuff)
+        writer = csv.DictWriter(fh, fieldnames=samplesheet_data[0].keys())
+        writer.writeheader()
+        writer.writerows(samplesheet_data)
+    return samplesheet_file, samplesheet_data
+
+
 _runfolder1 = Runfolder(name="160930_ST-E00216_0111_BH37CWALXX",
                         path="/foo/160930_ST-E00216_0111_BH37CWALXX")
 
@@ -62,8 +249,8 @@ _runfolder2.projects = [RunfolderProject(name="ABC_123",
                                          runfolder_path=_runfolder2.path,
                                          runfolder_name="160930_ST-E00216_0112_BH37CWALXX")]
 
-
 FAKE_RUNFOLDERS = [_runfolder1, _runfolder2]
+UNORGANISED_RUNFOLDER = unorganised_runfolder()
 
 
 def assert_eventually_equals(self, timeout, f, expected, delay=0.1):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,11 +72,9 @@ def bool_generator():
         yield int(item) % 2 == 0
 
 
-def project_sample(project, sample_name, sample_index, lane_no, subdir=False):
+def project_sample(project, sample_name, sample_index, lane_no, sample_id=None):
     sample_files = []
-    sample_id = None
-    if subdir:
-        sample_id = "{}_id".format(sample_name)
+    if sample_id:
         sample_dir = os.path.join(project.path, sample_id)
     else:
         sample_dir = project.path
@@ -144,11 +142,9 @@ def runfolder_project(
             sample_name=sample_name,
             sample_index=si,
             lane_no=l,
-            subdir=True)
+            sample_id="{}-{}-{}".format(sample_name, si, l))
         for si in [next(sample_indexes), next(sample_indexes)] for l in [next(lane_numbers), next(lane_numbers)]]
-    sample = t_samples[0]
-    sample.sample_files = [f for s in t_samples for f in s.sample_files]
-    samples.append(sample)
+    samples.extend(t_samples)
 
     project.samples = samples
     return project

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,10 +31,11 @@ fake_directories = ["160930_ST-E00216_0111_BH37CWALXX",
 fake_projects = ["ABC_123", "DEF_456"]
 
 
-def mock_file_system_service(directories, projects):
+def mock_file_system_service(directories, projects, fastq_files=None):
     mock_file_system_service_instance = MagicMock()
     mock_file_system_service_instance.find_runfolder_directories.return_value = directories
     mock_file_system_service_instance.find_project_directories.return_value = projects
+    mock_file_system_service_instance.list_files_recursively.return_value = fastq_files or []
     return mock_file_system_service_instance
 
 _runfolder1 = Runfolder(name="160930_ST-E00216_0111_BH37CWALXX",
@@ -71,7 +72,7 @@ def assert_eventually_equals(self, timeout, f, expected, delay=0.1):
     while True:
         try:
             value = f()
-            self.assertEquals(value, expected)
+            self.assertEqual(value, expected)
             break
         except AssertionError:
             if time.time() - start_time <= timeout:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,8 +93,8 @@ def project_sample(project, sample_name, sample_index, lane_no, sample_id=None):
                     sample_path=sample_path,
                     sample_name=sample_name,
                     sample_index=sample_index,
-                    lane_no=lane_no,
-                    read_no=read_no,
+                    lane_no=int(lane_no),
+                    read_no=int(read_no),
                     is_index=is_index,
                     checksum="checksum-for-{}".format(sample_path)))
     return Sample(

--- a/tests/unit_tests/repositories/test_runfolder_repository.py
+++ b/tests/unit_tests/repositories/test_runfolder_repository.py
@@ -4,7 +4,8 @@ from delivery.models.runfolder import Runfolder
 from delivery.models.project import RunfolderProject
 from delivery.repositories.runfolder_repository import FileSystemBasedRunfolderRepository
 
-from tests.test_utils import FAKE_RUNFOLDERS, mock_file_system_service, fake_directories, fake_projects
+from tests.test_utils import FAKE_RUNFOLDERS, mock_file_system_service, mock_metadata_service, fake_directories, \
+    fake_projects
 
 
 class TestRunfolderRepository(unittest.TestCase):
@@ -13,8 +14,11 @@ class TestRunfolderRepository(unittest.TestCase):
 
     file_system_service = mock_file_system_service(fake_directories,
                                                    fake_projects)
+    metadata_service = mock_metadata_service()
+
     repo = FileSystemBasedRunfolderRepository(base_path="/foo",
-                                              file_system_service=file_system_service)
+                                              file_system_service=file_system_service,
+                                              metadata_service=metadata_service)
 
     def test_get_runfolders(self):
         actual_runfolders = list(self.repo.get_runfolders())
@@ -33,7 +37,8 @@ class TestRunfolderRepository(unittest.TestCase):
         file_system_service = mock_file_system_service(with_non_runfolder_dir,
                                                        fake_projects)
         repo = FileSystemBasedRunfolderRepository(base_path="/foo",
-                                                  file_system_service=file_system_service)
+                                                  file_system_service=file_system_service,
+                                                  metadata_service=self.metadata_service)
         actual_runfolders = list(repo.get_runfolders())
         self.assertListEqual(self.expected_runfolders, actual_runfolders)
 

--- a/tests/unit_tests/repositories/test_sample_repository.py
+++ b/tests/unit_tests/repositories/test_sample_repository.py
@@ -1,0 +1,89 @@
+
+import os
+import unittest
+
+from delivery.exceptions import FileNameParsingException
+from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
+
+from tests import test_utils
+
+
+class TestSampleRepository(unittest.TestCase):
+
+    def setUp(self):
+        self.project = test_utils.FAKE_RUNFOLDERS[0].projects[0]
+        no_samples = 3
+        sample_names = ["Sample{}".format(str(i)) for i in range(no_samples)]
+        sample_index = ["S{}".format(str(i)) for i in range(no_samples)]
+        lane_no = [1, 2, 3]
+        is_index = [False, True]
+        read_no = [1, 2]
+        sample_paths = [
+            os.path.join(self.project.path, "Sample_{}".format(sample_names[0])),
+            self.project.path,
+            os.path.join(self.project.path, sample_names[2])
+        ]
+        self.fastq_files = []
+        for i in range(no_samples):
+            for ii in is_index:
+                for r in read_no:
+                    file_name = "_".join([
+                        sample_names[i],
+                        sample_index[i],
+                        "L00{}".format(str(lane_no[i])),
+                        "{}{}".format(
+                            "I" if ii else "R",
+                            str(r)
+                        ),
+                        "001.fastq.gz"])
+                    self.fastq_files.append(os.path.join(sample_paths[i], file_name))
+        file_system_service = test_utils.mock_file_system_service([], [], fastq_files=self.fastq_files)
+        self.sample_repo = RunfolderProjectBasedSampleRepository(file_system_service=file_system_service)
+
+    def test_get_samples(self):
+        for sample in self.sample_repo.get_samples(self.project):
+            self.assertEqual(self.project.name, sample.project_name)
+            self.assertEqual(4, len(sample.sample_files))
+
+    def test_sample_file_from_sample_path(self):
+        bad_filenames = [
+            "this-is-not-a-proper-fastq-file-name",
+            "not_ok_S1_L002_R1_001.fastq",
+            "not_ok_ACGGTG_L001_I1_001.fastq.gz",
+            "will_not_work_S1_L010_R1_001.fastq.gz"]
+        for bad_filename in bad_filenames:
+            self.assertRaises(
+                FileNameParsingException,
+                self.sample_repo.sample_file_from_sample_path,
+                bad_filename)
+
+        sample_names = ["this-is-ok", "ok", "this_is_ok", "this_is_ok_S8_L008_R3"]
+        sample_index = ["S0", "S1", "S999"]
+        lane_no = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        is_index = [True, False]
+        read_no = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        suffix = ["001.fastq.gz", "002.fastq.gz", "999.fastq.gz"]
+
+        # this may be a bit over the top but what the heck..
+        for sn in sample_names:
+            for si in sample_index:
+                for l in lane_no:
+                    for i in is_index:
+                        for r in read_no:
+                            for sx in suffix:
+                                good_filename = "_".join([
+                                    sn,
+                                    si,
+                                    "L00{}".format(str(l)),
+                                    "{}{}".format(
+                                        "I" if i else "R",
+                                        str(r)),
+                                    sx])
+                                observed_sample_file = self.sample_repo.sample_file_from_sample_path(good_filename)
+                                self.assertTrue(all([
+                                    sn == observed_sample_file.sample_name,
+                                    si == observed_sample_file.sample_index,
+                                    l == observed_sample_file.lane_no,
+                                    i == observed_sample_file.is_index,
+                                    r == observed_sample_file.read_no
+                                ]))

--- a/tests/unit_tests/repositories/test_sample_repository.py
+++ b/tests/unit_tests/repositories/test_sample_repository.py
@@ -15,10 +15,10 @@ class TestSampleRepository(unittest.TestCase):
         self.runfolder = test_utils.UNORGANISED_RUNFOLDER
         self.project = self.runfolder.projects[0]
         self.fastq_files = [
-            sample_file.sample_path for sample in self.project.samples for sample_file in sample.sample_files]
+            sample_file.file_path for sample in self.project.samples for sample_file in sample.sample_files]
         self.runfolder.checksums = {
             os.path.relpath(
-                sample_file.sample_path,
+                sample_file.file_path,
                 os.path.dirname(self.runfolder.path)): sample_file.checksum
             for sample in self.project.samples for sample_file in sample.sample_files}
         self.file_system_service = test_utils.mock_file_system_service([], [], fastq_files=self.fastq_files)

--- a/tests/unit_tests/repositories/test_sample_repository.py
+++ b/tests/unit_tests/repositories/test_sample_repository.py
@@ -26,6 +26,7 @@ class TestSampleRepository(unittest.TestCase):
 
     def test_get_samples(self):
         self.file_system_service.relpath.side_effect = os.path.relpath
+        self.file_system_service.dirname = os.path.dirname
         for sample in self.sample_repo.get_samples(self.project, self.runfolder):
             self.assertIn(sample, self.project.samples)
 

--- a/tests/unit_tests/repositories/test_sample_repository.py
+++ b/tests/unit_tests/repositories/test_sample_repository.py
@@ -29,6 +29,12 @@ class TestSampleRepository(unittest.TestCase):
         self.file_system_service.dirname = os.path.dirname
         for sample in self.sample_repo.get_samples(self.project, self.runfolder):
             self.assertIn(sample, self.project.samples)
+            for sample_file in sample.sample_files:
+                sample_file_subdir = os.path.dirname(
+                    os.path.relpath(
+                        sample_file.file_path,
+                        self.project.path))
+                self.assertTrue(sample_file_subdir == sample.sample_id or sample_file_subdir == "")
 
     def test_sample_file_from_sample_path_bad(self):
         bad_filenames = [

--- a/tests/unit_tests/services/test_file_system_service.py
+++ b/tests/unit_tests/services/test_file_system_service.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 
 from delivery.services.file_system_service import FileSystemService
-
+from tests import test_utils
 
 class TestFileSystemService(unittest.TestCase):
 
@@ -35,3 +35,8 @@ class TestFileSystemService(unittest.TestCase):
             sorted(self.files),
             sorted(list(FileSystemService().list_files_recursively(self.rootdir)))
         )
+
+    def test_extract_samplesheet_data(self):
+        runfolder = test_utils.unorganised_runfolder(self.rootdir)
+        samplesheet_file, samplesheet_data = test_utils.samplesheet_file_from_runfolder(runfolder)
+        self.assertListEqual(samplesheet_data, FileSystemService.extract_samplesheet_data(samplesheet_file))

--- a/tests/unit_tests/services/test_file_system_service.py
+++ b/tests/unit_tests/services/test_file_system_service.py
@@ -1,11 +1,10 @@
 
-import os
 import shutil
 import tempfile
 import unittest
 
 from delivery.services.file_system_service import FileSystemService
-from tests import test_utils
+
 
 class TestFileSystemService(unittest.TestCase):
 
@@ -35,8 +34,3 @@ class TestFileSystemService(unittest.TestCase):
             sorted(self.files),
             sorted(list(FileSystemService().list_files_recursively(self.rootdir)))
         )
-
-    def test_extract_samplesheet_data(self):
-        runfolder = test_utils.unorganised_runfolder(self.rootdir)
-        samplesheet_file, samplesheet_data = test_utils.samplesheet_file_from_runfolder(runfolder)
-        self.assertListEqual(samplesheet_data, FileSystemService.extract_samplesheet_data(samplesheet_file))

--- a/tests/unit_tests/services/test_file_system_service.py
+++ b/tests/unit_tests/services/test_file_system_service.py
@@ -1,0 +1,37 @@
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from delivery.services.file_system_service import FileSystemService
+
+
+class TestFileSystemService(unittest.TestCase):
+
+    @staticmethod
+    def _tempfiles(dir, n):
+        return [tempfile.mkstemp(dir=dir)[1] for i in range(n)]
+
+    @staticmethod
+    def _tempdirs(dir, n):
+        return [tempfile.mkdtemp(dir=dir) for i in range(n)]
+
+    def setUp(self):
+        self.rootdir = tempfile.mkdtemp()
+        self.dirs = []
+        self.files = []
+        self.dirs.extend(self._tempdirs(self.rootdir, 2))
+        self.dirs.extend(self._tempdirs(self.dirs[1], 2))
+        self.files.extend(self._tempfiles(self.rootdir, 3))
+        self.files.extend(self._tempfiles(self.dirs[0], 3))
+        self.files.extend(self._tempfiles(self.dirs[-1], 3))
+
+    def tearDown(self):
+        shutil.rmtree(self.rootdir)
+
+    def test_list_files_recursively(self):
+        self.assertListEqual(
+            sorted(self.files),
+            sorted(list(FileSystemService().list_files_recursively(self.rootdir)))
+        )

--- a/tests/unit_tests/services/test_metadata_service.py
+++ b/tests/unit_tests/services/test_metadata_service.py
@@ -21,3 +21,21 @@ class TestMetadataService(unittest.TestCase):
         runfolder = test_utils.unorganised_runfolder(self.rootdir)
         samplesheet_file, samplesheet_data = test_utils.samplesheet_file_from_runfolder(runfolder)
         self.assertListEqual(samplesheet_data, self.metadata_service.extract_samplesheet_data(samplesheet_file))
+
+    def test_hash_string(self):
+        expected_results = (
+            ("this-is-a-string-to-be-hashed", "c302b90acbbdb4f2d3a348ec9149a3a4"),
+            ("this-is-another-string-to-be-hashed", "c77fbba716fea197fe03348885232daa"))
+
+        # supplying a new query should be independent from a previous query
+        for expected_result in expected_results:
+            self.assertEqual(expected_result[1], self.metadata_service.hash_string(expected_result[0]))
+
+    def test_hash_string_consecutive(self):
+        test_strings = ("this-is-a-string-to-be-hashed", "this-is-another-string-to-be-hashed")
+        expected_hash = "c10dabfa349ea41d244a68d7b4e9312f"
+        hash_obj = self.metadata_service.get_hash_object()
+        observed_hash = None
+        for test_string in test_strings:
+            observed_hash = self.metadata_service.hash_string(test_string, hasher_obj=hash_obj)
+        self.assertEqual(expected_hash, observed_hash)

--- a/tests/unit_tests/services/test_metadata_service.py
+++ b/tests/unit_tests/services/test_metadata_service.py
@@ -1,0 +1,23 @@
+
+import shutil
+import tempfile
+import unittest
+
+from delivery.services.metadata_service import MetadataService
+
+from tests import test_utils
+
+
+class TestMetadataService(unittest.TestCase):
+
+    def setUp(self):
+        self.rootdir = tempfile.mkdtemp()
+        self.metadata_service = MetadataService()
+
+    def tearDown(self):
+        shutil.rmtree(self.rootdir)
+
+    def test_extract_samplesheet_data(self):
+        runfolder = test_utils.unorganised_runfolder(self.rootdir)
+        samplesheet_file, samplesheet_data = test_utils.samplesheet_file_from_runfolder(runfolder)
+        self.assertListEqual(samplesheet_data, self.metadata_service.extract_samplesheet_data(samplesheet_file))

--- a/tests/unit_tests/services/test_metadata_service.py
+++ b/tests/unit_tests/services/test_metadata_service.py
@@ -1,7 +1,8 @@
 
+import os
 import shutil
-import tempfile
 import unittest
+import tempfile
 
 from delivery.services.metadata_service import MetadataService
 
@@ -39,3 +40,11 @@ class TestMetadataService(unittest.TestCase):
         for test_string in test_strings:
             observed_hash = self.metadata_service.hash_string(test_string, hasher_obj=hash_obj)
         self.assertEqual(expected_hash, observed_hash)
+
+    def test_hash_file(self):
+        strings_to_hash = ("this-is-a-string-to-be-hashed\n", "this-is-another-string-to-be-hashed\n")
+        expected_hash = "7d652ebbbedfeef99e737e5768fa691c"
+        fd, file_to_hash = tempfile.mkstemp(text=True)
+        with os.fdopen(fd, 'w') as fh:
+            fh.writelines(strings_to_hash)
+        self.assertEqual(expected_hash, MetadataService.hash_file(file_to_hash))

--- a/tests/unit_tests/services/test_organise_service.py
+++ b/tests/unit_tests/services/test_organise_service.py
@@ -4,6 +4,7 @@ import unittest
 
 from delivery.exceptions import ProjectAlreadyOrganisedException
 from delivery.models.runfolder import RunfolderFile
+from delivery.models.sample import Sample
 from delivery.repositories.project_repository import GeneralProjectRepository
 from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 from delivery.services.file_system_service import FileSystemService

--- a/tests/unit_tests/services/test_organise_service.py
+++ b/tests/unit_tests/services/test_organise_service.py
@@ -1,0 +1,108 @@
+import mock
+import os
+import unittest
+
+from delivery.exceptions import ProjectAlreadyOrganisedException
+from delivery.models.sample import Sample, SampleFile
+from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
+from delivery.services.file_system_service import FileSystemService
+from delivery.services.runfolder_service import RunfolderService
+from delivery.services.organise_service import OrganiseService
+
+from tests import test_utils
+
+
+class TestOrganiseService(unittest.TestCase):
+
+    def setUp(self):
+        self.project = test_utils.FAKE_RUNFOLDERS[0].projects[0]
+        file_root_path = os.path.join(self.project.runfolder_path, "Unaligned")
+        self.samples = [
+            Sample("Sample1", self.project.name),
+            Sample("Sample2", self.project.name)]
+        for sample in self.samples:
+            sample.sample_files = [
+                SampleFile(
+                    os.path.join(file_root_path, "sample_file_lane_{}".format(i)),
+                    lane_no=i) for i in range(1, 4)]
+            file_root_path = os.path.join(file_root_path, "Sample_{}".format(self.samples[1].name))
+        self.file_system_service = mock.MagicMock(spec=FileSystemService)
+        self.sample_repository = mock.MagicMock(spec=RunfolderProjectBasedSampleRepository)
+        self.runfolder_service = mock.MagicMock(spec=RunfolderService)
+        self.organise_service = OrganiseService(
+            self.runfolder_service,
+            self.sample_repository,
+            file_system_service=self.file_system_service)
+
+    def test_organise_runfolder(self):
+        self.runfolder_service.find_projects_on_runfolder.side_effect = yield from [self.project]
+        with mock.patch.object(self.organise_service, "organise_project", autospec=True) as organise_project_mock:
+            runfolder_id = self.project.runfolder_name
+            lanes = [1, 2, 3]
+            projects = ["a", "b", "c"]
+            force = False
+            self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
+            organise_project_mock.assert_called_once_with(self.project, lanes, force)
+
+    def test_organise_project_already_organised(self):
+        self.file_system_service.exists.return_value = True
+
+        # without force
+        self.assertRaises(
+            ProjectAlreadyOrganisedException,
+            self.organise_service.organise_project,
+            self.project, [], False)
+
+        # with force
+        organised_path = os.path.join(self.project.runfolder_path, "Projects")
+        self.sample_repository.get_samples.return_value = []
+        self.organise_service.organise_project(self.project, [], True)
+        self.file_system_service.rename.assert_called_once()
+        self.assertEqual(organised_path, self.file_system_service.rename.call_args[0][0])
+        self.assertRegex(
+            self.file_system_service.rename.call_args[0][1],
+            "{}\\.\\d+\\.\\d+".format(organised_path))
+
+    def test_organise_project(self):
+        self.sample_repository.get_samples.return_value = self.samples
+        organised_project_path = os.path.join(self.project.runfolder_path, "Projects", self.project.name)
+        with mock.patch.object(self.organise_service, "organise_sample", autospec=True) as organise_sample_mock:
+            lanes = [1, 2, 3]
+            force = True
+            self.organise_service.organise_project(self.project, lanes, force)
+            for sample in self.samples:
+                organise_sample_mock.assert_has_calls([
+                    mock.call(
+                        sample,
+                        organised_project_path,
+                        lanes)])
+
+    def test_organise_sample(self):
+
+        # relative symlinks should be created with the correct arguments
+        self.file_system_service.relpath.side_effect = os.path.relpath
+        for sample in self.samples:
+            organised_sample = self.organise_service.organise_sample(sample, self.project.path, [])
+            sample_file_dir = os.path.relpath(
+                os.path.dirname(
+                    sample.sample_files[0].sample_path),
+                self.project.runfolder_path)
+            relative_path = os.path.join("..", "..", "..", sample_file_dir)
+            self.file_system_service.symlink.assert_has_calls([
+                mock.call(
+                    os.path.join(relative_path, os.path.basename(sample_file.sample_path)),
+                    sample_file.sample_path) for sample_file in organised_sample.sample_files])
+
+    def test_organise_sample_exclude_by_lane(self):
+
+        # all sample lanes are excluded
+        for sample in self.samples:
+            organised_sample = self.organise_service.organise_sample(sample, self.project.path, [0])
+            self.assertListEqual([], organised_sample.sample_files)
+
+        # a specific sample lane is excluded
+        for sample in self.samples:
+            organised_sample = self.organise_service.organise_sample(sample, self.project.path, [2, 3])
+            self.assertEqual(0, len(list(filter(lambda f: f.lane_no == 1, organised_sample.sample_files))))
+            self.assertEqual(2, len(list(filter(lambda f: f.lane_no != 1, organised_sample.sample_files))))
+

--- a/tests/unit_tests/services/test_organise_service.py
+++ b/tests/unit_tests/services/test_organise_service.py
@@ -4,6 +4,7 @@ import unittest
 
 from delivery.exceptions import ProjectAlreadyOrganisedException
 from delivery.models.sample import Sample, SampleFile
+from delivery.repositories.project_repository import GeneralProjectRepository
 from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 from delivery.services.file_system_service import FileSystemService
 from delivery.services.runfolder_service import RunfolderService
@@ -15,34 +16,30 @@ from tests import test_utils
 class TestOrganiseService(unittest.TestCase):
 
     def setUp(self):
-        self.project = test_utils.FAKE_RUNFOLDERS[0].projects[0]
-        file_root_path = os.path.join(self.project.runfolder_path, "Unaligned")
-        self.samples = [
-            Sample("Sample1", self.project.name),
-            Sample("Sample2", self.project.name)]
-        for sample in self.samples:
-            sample.sample_files = [
-                SampleFile(
-                    os.path.join(file_root_path, "sample_file_lane_{}".format(i)),
-                    lane_no=i) for i in range(1, 4)]
-            file_root_path = os.path.join(file_root_path, "Sample_{}".format(self.samples[1].name))
+        self.runfolder = test_utils.UNORGANISED_RUNFOLDER
+        self.project = self.runfolder.projects[0]
+        self.organised_project_path = os.path.join(
+            self.project.runfolder_path,
+            "Projects",
+            self.project.name,
+            self.runfolder.name)
         self.file_system_service = mock.MagicMock(spec=FileSystemService)
-        self.sample_repository = mock.MagicMock(spec=RunfolderProjectBasedSampleRepository)
         self.runfolder_service = mock.MagicMock(spec=RunfolderService)
+        self.project_repository = mock.MagicMock(spec=GeneralProjectRepository)
+        self.sample_repository = mock.MagicMock(spec=RunfolderProjectBasedSampleRepository)
         self.organise_service = OrganiseService(
             self.runfolder_service,
-            self.sample_repository,
             file_system_service=self.file_system_service)
 
     def test_organise_runfolder(self):
         self.runfolder_service.find_projects_on_runfolder.side_effect = yield from [self.project]
         with mock.patch.object(self.organise_service, "organise_project", autospec=True) as organise_project_mock:
-            runfolder_id = self.project.runfolder_name
+            runfolder_id = self.runfolder.name
             lanes = [1, 2, 3]
             projects = ["a", "b", "c"]
             force = False
             self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
-            organise_project_mock.assert_called_once_with(self.project, lanes, force)
+            organise_project_mock.assert_called_once_with(self.runfolder, self.project, lanes, force)
 
     def test_organise_project_already_organised(self):
         self.file_system_service.exists.return_value = True
@@ -51,12 +48,12 @@ class TestOrganiseService(unittest.TestCase):
         self.assertRaises(
             ProjectAlreadyOrganisedException,
             self.organise_service.organise_project,
-            self.project, [], False)
+            self.runfolder, self.project, [], False)
 
         # with force
         organised_path = os.path.join(self.project.runfolder_path, "Projects")
         self.sample_repository.get_samples.return_value = []
-        self.organise_service.organise_project(self.project, [], True)
+        self.organise_service.organise_project(self.runfolder, self.project, [], True)
         self.file_system_service.rename.assert_called_once()
         self.assertEqual(organised_path, self.file_system_service.rename.call_args[0][0])
         self.assertRegex(
@@ -64,30 +61,27 @@ class TestOrganiseService(unittest.TestCase):
             "{}\\.\\d+\\.\\d+".format(organised_path))
 
     def test_organise_project(self):
-        self.sample_repository.get_samples.return_value = self.samples
-        organised_project_path = os.path.join(self.project.runfolder_path, "Projects", self.project.name)
         with mock.patch.object(self.organise_service, "organise_sample", autospec=True) as organise_sample_mock:
             lanes = [1, 2, 3]
             force = True
-            self.organise_service.organise_project(self.project, lanes, force)
-            for sample in self.samples:
+            self.organise_service.organise_project(self.runfolder, self.project, lanes, force)
+            for sample in self.project.samples:
                 organise_sample_mock.assert_has_calls([
                     mock.call(
                         sample,
-                        organised_project_path,
+                        self.organised_project_path,
                         lanes)])
 
     def test_organise_sample(self):
-
         # relative symlinks should be created with the correct arguments
         self.file_system_service.relpath.side_effect = os.path.relpath
-        for sample in self.samples:
-            organised_sample = self.organise_service.organise_sample(sample, self.project.path, [])
+        for sample in self.project.samples:
+            organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [])
             sample_file_dir = os.path.relpath(
                 os.path.dirname(
                     sample.sample_files[0].sample_path),
                 self.project.runfolder_path)
-            relative_path = os.path.join("..", "..", "..", sample_file_dir)
+            relative_path = os.path.join("..", "..", "..", "..", sample_file_dir)
             self.file_system_service.symlink.assert_has_calls([
                 mock.call(
                     os.path.join(relative_path, os.path.basename(sample_file.sample_path)),
@@ -96,13 +90,14 @@ class TestOrganiseService(unittest.TestCase):
     def test_organise_sample_exclude_by_lane(self):
 
         # all sample lanes are excluded
-        for sample in self.samples:
-            organised_sample = self.organise_service.organise_sample(sample, self.project.path, [0])
+        for sample in self.project.samples:
+            organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [0])
             self.assertListEqual([], organised_sample.sample_files)
 
         # a specific sample lane is excluded
-        for sample in self.samples:
-            organised_sample = self.organise_service.organise_sample(sample, self.project.path, [2, 3])
-            self.assertEqual(0, len(list(filter(lambda f: f.lane_no == 1, organised_sample.sample_files))))
-            self.assertEqual(2, len(list(filter(lambda f: f.lane_no != 1, organised_sample.sample_files))))
+        for sample in self.project.samples:
+            organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [2, 3])
+            self.assertListEqual(
+                list(map(lambda x: x.file_name, filter(lambda f: f.lane_no in [2, 3], sample.sample_files))),
+                list(map(lambda x: x.file_name, organised_sample.sample_files)))
 

--- a/tests/unit_tests/services/test_organise_service.py
+++ b/tests/unit_tests/services/test_organise_service.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from delivery.exceptions import ProjectAlreadyOrganisedException
-from delivery.models.project import RunfolderProject
+from delivery.models.runfolder import RunfolderFile
 from delivery.repositories.project_repository import GeneralProjectRepository
 from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 from delivery.services.file_system_service import FileSystemService
@@ -92,17 +92,24 @@ class TestOrganiseService(unittest.TestCase):
         with mock.patch.object(
                 self.organise_service, "organise_sample", autospec=True) as organise_sample_mock, \
                 mock.patch.object(
-                    self.organise_service, "symlink_project_report", autospec=True) as symlink_report_mock:
+                self.organise_service, "organise_project_file", autospec=True) as organise_project_file_mock:
+            self.file_system_service.dirname.side_effect = os.path.dirname
             lanes = [1, 2, 3]
             organised_projects_path = os.path.join(self.project.runfolder_path, "Projects")
             self.organise_service.organise_project(self.runfolder, self.project, organised_projects_path, lanes)
-            for sample in self.project.samples:
-                organise_sample_mock.assert_has_calls([
-                    mock.call(
-                        sample,
-                        self.organised_project_path,
-                        lanes)])
-            self.assertEqual(1, symlink_report_mock.call_count)
+            organise_sample_mock.assert_has_calls([
+                mock.call(
+                    sample,
+                    self.organised_project_path,
+                    lanes)
+                for sample in self.project.samples])
+            organise_project_file_mock.assert_has_calls([
+                mock.call(
+                    project_file,
+                    os.path.join(organised_projects_path, self.project.name, self.project.runfolder_name),
+                    project_file_base=os.path.dirname(self.project.project_files[0].file_path)
+                )
+                for project_file in self.project.project_files])
 
     def test_organise_sample(self):
         # relative symlinks should be created with the correct arguments
@@ -112,13 +119,13 @@ class TestOrganiseService(unittest.TestCase):
             organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [])
             sample_file_dir = os.path.relpath(
                 os.path.dirname(
-                    sample.sample_files[0].sample_path),
+                    sample.sample_files[0].file_path),
                 self.project.runfolder_path)
             relative_path = os.path.join("..", "..", "..", "..", sample_file_dir)
             self.file_system_service.symlink.assert_has_calls([
                 mock.call(
-                    os.path.join(relative_path, os.path.basename(sample_file.sample_path)),
-                    sample_file.sample_path) for sample_file in organised_sample.sample_files])
+                    os.path.join(relative_path, os.path.basename(sample_file.file_path)),
+                    sample_file.file_path) for sample_file in organised_sample.sample_files])
 
     def test_organise_sample_exclude_by_lane(self):
 
@@ -142,7 +149,7 @@ class TestOrganiseService(unittest.TestCase):
                 organised_sample_path = os.path.join(
                     os.path.dirname(
                         os.path.dirname(
-                            sample_file.sample_path)),
+                            sample_file.file_path)),
                     "{}_organised".format(sample.sample_id))
                 organised_sample_file = self.organise_service.organise_sample_file(
                     sample_file,
@@ -156,38 +163,43 @@ class TestOrganiseService(unittest.TestCase):
 
                 expected_link_path = os.path.join(
                     organised_sample_path,
-                    os.path.basename(sample_file.sample_path))
+                    os.path.basename(sample_file.file_path))
                 self.assertEqual(
                     expected_link_path,
-                    organised_sample_file.sample_path)
+                    organised_sample_file.file_path)
                 self.file_system_service.symlink.assert_called_with(
                     os.path.join(
                         "..",
                         os.path.basename(
-                            os.path.dirname(sample_file.sample_path)),
-                        os.path.basename(sample_file.sample_path)),
+                            os.path.dirname(sample_file.file_path)),
+                        os.path.basename(sample_file.file_path)),
                     expected_link_path)
                 for attr in ("file_name", "sample_name", "sample_index", "lane_no", "read_no", "is_index", "checksum"):
                     self.assertEqual(
                         getattr(sample_file, attr),
                         getattr(organised_sample_file, attr))
 
-    def test_symlink_project_report(self):
+    def test_organise_project_file(self):
         organised_project_path = "/bar/project"
-        organised_project = RunfolderProject(
-            self.project.name,
-            organised_project_path,
-            self.project.runfolder_path,
-            self.project.runfolder_name)
-        project_report_base = "/foo"
-        project_report_files = [
-            os.path.join(project_report_base, "a-report-file"),
-            os.path.join(project_report_base, "report-dir", "another-report-file")
-        ]
-        self.runfolder_service.get_project_report_files.return_value = project_report_base, project_report_files
+        project_file_base = "/foo"
+        project_files = [
+            RunfolderFile(
+                os.path.join(
+                    project_file_base,
+                    project_file),
+                file_checksum="checksum-for-{}".format(project_file))
+            for project_file in ("a-report-file", os.path.join("report-dir", "another-report-file"))]
         self.file_system_service.relpath.side_effect = os.path.relpath
         self.file_system_service.dirname.side_effect = os.path.dirname
-        self.organise_service.symlink_project_report(self.project, organised_project)
+        for project_file in project_files:
+            organised_project_file = self.organise_service.organise_project_file(
+                project_file, organised_project_path, project_file_base)
+            self.assertEqual(
+                os.path.join(
+                    organised_project_path,
+                    os.path.relpath(project_file.file_path, project_file_base)),
+                organised_project_file.file_path)
+            self.assertEqual(project_file.checksum, organised_project_file.checksum)
         self.file_system_service.symlink.assert_has_calls([
             mock.call(
                 os.path.join("..", "..", "foo", "a-report-file"),


### PR DESCRIPTION
**What problems does this PR solve?**

This PR introduces an OrganisationService for organizing a runfolder in preparation for staging and delivery. Upon organisation, project data (fastq files and sequence reports) will be symlinked to a project-specific directory in the runfolder. The hierarchy will be  `Projects/<project name>/<runfolder name>/`. Each sample will be placed in its own subdirectory. A project-specific file with checksums will be placed in the organized folder, as well as a sample sheet where all entries not belonging to the project has been masked.

In summary:

* An API endpoint and corresponding OrganisationHandler are introduced.
* the Runfolder and Project models have been extended
* models for Sample and SampleFile objects have been added
* Repositories for managing Samples, Unorganized projects and runfolders have been added
* services have been extended
* the test suite has been expanded with an integration test, unit tests and utility functions

**How has the changes been tested?**

the test suite includes unit tests and an integration test. In addition, I've run the service in a Docker container and tested organisation with a range of input alternatives. 

**Reasons for careful code review**

This code will have a direct effect on what data is made available to the downstream delivery operations and as such, should be carefully code reviewed and tested. The code will not remove any data per se but silently failing to organize or mixing up samples would have serious consequences for what is delivered to the end user.

  - [X] 
