### PR TITLE
do not throw exception on missing project files

### DIFF
--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -129,7 +129,11 @@ class UnorganisedRunfolderProjectRepository(object):
                 runfolder_path=runfolder.path,
                 runfolder_name=runfolder.name
             )
-            project.project_files = self.get_report_files(project, checksums=runfolder.checksums)
+            try:
+                project.project_files = self.get_report_files(project, checksums=runfolder.checksums)
+            except ProjectReportNotFoundException as e:
+                log.warning(e)
+
             project.samples = self.sample_repository.get_samples(project, runfolder)
             return project
 

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -166,8 +166,8 @@ class TestIntegration(AsyncHTTPTestCase):
                         os.path.basename(samplesheet_file)),
                     MetadataService.hash_file(samplesheet_file))
 
-                project_file_base = os.path.dirname(project.project_files[0].file_path)
                 for project_file in project.project_files:
+                    project_file_base = os.path.dirname(project.project_files[0].file_path)
                     relative_path = os.path.relpath(project_file.file_path, project_file_base)
                     organised_project_file_path = os.path.join(organised_path, relative_path)
                     self.assertTrue(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,6 +160,14 @@ def unorganised_runfolder(name="180124_A00181_0019_BH72M5DMXX", root_path="/foo"
             project_name=p,
             sample_indexes=sample_indexes,
             lane_numbers=lane_numbers) for p in fake_projects]
+    # add another project with missing files
+    project = runfolder_project(
+        runfolder,
+        project_name="GHI_789",
+        sample_indexes=sample_indexes,
+        lane_numbers=lane_numbers)
+    project.project_files = []
+    runfolder.projects.append(project)
     checksums = {}
     for project in runfolder.projects:
         for sample in project.samples:

--- a/tests/unit_tests/repositories/test_project_repository.py
+++ b/tests/unit_tests/repositories/test_project_repository.py
@@ -1,12 +1,16 @@
 
+import os
+import mock
 import unittest
-from mock import MagicMock
 
+from delivery.exceptions import ProjectReportNotFoundException
 from delivery.models.project import GeneralProject, RunfolderProject
-from delivery.repositories.project_repository import GeneralProjectRepository
+from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository
+from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 from delivery.services.file_system_service import FileSystemService
+from delivery.services.metadata_service import MetadataService
 
-from tests.test_utils import FAKE_RUNFOLDERS
+from tests.test_utils import UNORGANISED_RUNFOLDER
 
 
 class TestGeneralProjectRepository(unittest.TestCase):
@@ -26,3 +30,43 @@ class TestGeneralProjectRepository(unittest.TestCase):
 
         actual = repo.get_projects()
         self.assertEqual(list(actual), expected)
+
+
+class TestUnorganisedRunfolderProjectRepository(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.sample_repository = mock.create_autospec(RunfolderProjectBasedSampleRepository)
+        self.filesystem_service = mock.create_autospec(FileSystemService)
+        self.metadata_service = mock.create_autospec(MetadataService)
+        self.project_repository = UnorganisedRunfolderProjectRepository(
+            sample_repository=self.sample_repository,
+            filesystem_service=self.filesystem_service,
+            metadata_service=self.metadata_service)
+        self.runfolder = UNORGANISED_RUNFOLDER
+
+    def test_get_report_files(self):
+
+        # missing report files will raise an exception at this point
+        self.filesystem_service.exists.return_value = False
+        self.assertRaises(
+            ProjectReportNotFoundException,
+            self.project_repository.get_report_files,
+            self.runfolder.projects[0])
+
+    def test_get_projects(self):
+
+        expected_project_directories = map(lambda p: p.path, self.runfolder.projects)
+
+        self.filesystem_service.find_project_directories.side_effect = expected_project_directories
+        self.filesystem_service.list_files_recursively.return_value = ["file.fastq.gz"]
+        self.sample_repository.get_samples.return_value = None
+
+        # exceptions raised from missing report files should be handled
+        with mock.patch.object(
+                self.project_repository,
+                "get_report_files",
+                spec=UnorganisedRunfolderProjectRepository.get_report_files) as report_file_mock:
+            report_file_mock.side_effect = ProjectReportNotFoundException("mocked exception")
+            projects = self.project_repository.get_projects(self.runfolder)
+            for project in projects:
+                self.assertIsInstance(project, RunfolderProject)


### PR DESCRIPTION
**What problems does this PR solve?**

The organisation endpoint would raise an exception if report files were missing from an identified project in a runfolder. This was not the desired behavior so this PR ensures that a warning is raised but no exception will be raised.

**How has the changes been tested?**

Unit and integration test cases have been added to test this condition.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
