### PR TITLE
Add support for organising seqreports

### DIFF
--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -175,14 +175,16 @@ class UnorganisedRunfolderProjectRepository(object):
         if self.filesystem_service.exists(self.multiqc_report_path(project)):
             log.info("MultiQC reports found in Unaligned/{}, overriding organisation of seqreports".format(project.name))
             return list(map(_file_object_from_path, self.multiqc_report_files(project)))
-        if self.filesystem_service.exists(self.seqreports_path(project)):
-            return list(map(_file_object_from_path, self.seqreports_files(project)))
         for sisyphus_report_path in self.sisyphus_report_path(project):
             if self.filesystem_service.exists(sisyphus_report_path):
+                log.info("Organising sisyphus reports for {}".format(project.name))
                 return list(map(
                     _file_object_from_path,
                     self.sisyphus_report_files(
                         self.filesystem_service.dirname(sisyphus_report_path))))
+        if self.filesystem_service.exists(self.seqreports_path(project)):
+            log.info("Organising seqreports for {}".format(project.name))
+            return list(map(_file_object_from_path, self.seqreports_files(project)))
         raise ProjectReportNotFoundException("No project report found for {}".format(project.name))
 
     @staticmethod

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -172,10 +172,11 @@ class UnorganisedRunfolderProjectRepository(object):
             return RunfolderFile(file_path, file_checksum=checksum)
 
         checksums = checksums or {}
-        if self.filesystem_service.exists(self.seqreports_path(project)):
-            return list(map(_file_object_from_path, self.seqreports_path_files(project)))
         if self.filesystem_service.exists(self.multiqc_report_path(project)):
+            log.info("MultiQC reports found in Unaligned/{}, overriding organisation of seqreports".format(project.name))
             return list(map(_file_object_from_path, self.multiqc_report_files(project)))
+        if self.filesystem_service.exists(self.seqreports_path(project)):
+            return list(map(_file_object_from_path, self.seqreports_files(project)))
         for sisyphus_report_path in self.sisyphus_report_path(project):
             if self.filesystem_service.exists(sisyphus_report_path):
                 return list(map(

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -172,6 +172,8 @@ class UnorganisedRunfolderProjectRepository(object):
             return RunfolderFile(file_path, file_checksum=checksum)
 
         checksums = checksums or {}
+        if self.filesystem_service.exists(self.seqreports_path(project)):
+            return list(map(_file_object_from_path, self.seqreports_path_files(project)))
         if self.filesystem_service.exists(self.multiqc_report_path(project)):
             return list(map(_file_object_from_path, self.multiqc_report_files(project)))
         for sisyphus_report_path in self.sisyphus_report_path(project):
@@ -213,6 +215,20 @@ class UnorganisedRunfolderProjectRepository(object):
         report_dir = self.filesystem_service.dirname(report_files[0])
         report_files.append(
             os.path.join(report_dir, "{}_multiqc_report_data.zip".format(project.name)))
+        return report_files
+
+    @staticmethod
+    def seqreports_path(project):
+        return os.path.join(
+            project.runfolder_path, "seqreports", "projects", project.name,
+            "{}_{}_multiqc_report.html".format(project.runfolder_name, project.name))
+
+    def seqreports_files(self, project):
+        report_files = [self.seqreports_path(project)]
+        report_dir = self.filesystem_service.dirname(report_files[0])
+        report_files.append(
+            os.path.join(report_dir,
+                         "{}_{}_multiqc_report_data.zip".format(project.runfolder_name, project.name)))
         return report_files
 
     def is_sample_in_project(self, project, sample_project, sample_id, sample_lane):

--- a/tests/unit_tests/handlers/test_delivery_project_handlers.py
+++ b/tests/unit_tests/handlers/test_delivery_project_handlers.py
@@ -63,4 +63,4 @@ class TestProjectHandlers(AsyncHTTPTestCase):
         response = self.fetch(
             self.API_BASE + "/runfolders/160930_ST-E00216_0111_BH37CWALXX/projects")
         self.assertEqual(response.code, 200)
-        self.assertTrue(len(json.loads(response.body)["projects"]) == 2)
+        self.assertTrue(len(json.loads(response.body)["projects"]) == 3)

--- a/tests/unit_tests/repositories/test_project_repository.py
+++ b/tests/unit_tests/repositories/test_project_repository.py
@@ -70,3 +70,10 @@ class TestUnorganisedRunfolderProjectRepository(unittest.TestCase):
             projects = self.project_repository.get_projects(self.runfolder)
             for project in projects:
                 self.assertIsInstance(project, RunfolderProject)
+
+    def test_override_log_message(self):
+
+        self.filesystem_service.dirname.return_value = "foo/bar"
+        with self.assertLogs(level='INFO') as log:
+            self.project_repository.get_report_files(self.runfolder.projects[0])
+            self.assertIn('overriding organisation of seqreports', log.output[0])

--- a/tests/unit_tests/repositories/test_runfolder_repository.py
+++ b/tests/unit_tests/repositories/test_runfolder_repository.py
@@ -50,7 +50,7 @@ class TestRunfolderRepository(unittest.TestCase):
 
     def test_get_projects(self):
         actual_projects = list(self.repo.get_projects())
-        self.assertTrue(len(actual_projects) == 4)
+        self.assertTrue(len(actual_projects) == 6)
 
     def test_get_project(self):
         project_name = "ABC_123"


### PR DESCRIPTION
**What problems does this PR solve?**
This PR adds support for organising the new sequencing reports, they will have the highest priority. I'm not sure if it's better to look for the MultiQC reports in Unaligned first, let me know what you think. 

EDIT 190913:
Manually made reports in Unaligned will be checked for first, if they are used it will be documented in the log. 

**How has the changes been tested?**
Only automatic tests. 

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
