### PR TITLE
Implement delivery with DDS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Run Unit Tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        sudo apt install rsync -y
+        python -m pip install --upgrade pip
+        pip install wheel
+        pip install -r requirements/dev .
+    - name: Launch tests
+      run: |
+        nosetests ./tests

--- a/alembic/versions/e3aca4a6cd97_add_dds_project_id_column.py
+++ b/alembic/versions/e3aca4a6cd97_add_dds_project_id_column.py
@@ -1,0 +1,23 @@
+"""add dds_project_id column
+
+Revision ID: e3aca4a6cd97
+Revises: ea812cd3ab7b
+Create Date: 2022-04-26 10:04:45.348954
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e3aca4a6cd97'
+down_revision = 'ea812cd3ab7b'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('delivery_orders', sa.Column('dds_project_id', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('delivery_orders', 'dds_project_id')

--- a/config/app.config
+++ b/config/app.config
@@ -9,4 +9,7 @@ general_project_directory: tests/resources/projects
 staging_directory: /tmp/
 project_links_directory: /tmp/
 path_to_mover: '/usr/local/mover/1.0.0/'
+dds_conf:
+  token_path: auth.token
+  log_path: dds.log
 port: 9999

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -30,6 +30,7 @@ from delivery.repositories.sample_repository import RunfolderProjectBasedSampleR
 
 
 from delivery.services.mover_service import MoverDeliveryService
+from delivery.services.dds_service import DDSService
 from delivery.services.external_program_service import ExternalProgramService
 from delivery.services.staging_service import StagingService
 from delivery.services.file_system_service import FileSystemService
@@ -158,6 +159,13 @@ def compose_application(config):
                                                   delivery_repo=delivery_repo,
                                                   session_factory=session_factory,
                                                   path_to_mover=path_to_mover)
+
+    dds_conf = config['dds_conf']
+    dds_service = DDSService(external_program_service=external_program_service,
+                                                  staging_service=staging_service,
+                                                  delivery_repo=delivery_repo,
+                                                  session_factory=session_factory,
+                                                  dds_conf=dds_conf)
 
     delivery_sources_repo = DatabaseBasedDeliverySourcesRepository(session_factory=session_factory)
     runfolder_service = RunfolderService(runfolder_repo)

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -187,6 +187,7 @@ def compose_application(config):
                 external_program_service=external_program_service,
                 staging_service=staging_service,
                 mover_delivery_service=mover_delivery_service,
+                dds_service=dds_service,
                 delivery_service=delivery_service,
                 general_project_repo=general_project_repo,
                 best_practice_analysis_service=best_practice_analysis_service,

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -54,13 +54,27 @@ class DeliveryStatusHandler(ArteriaDeliveryBaseHandler):
 
     def initialize(self, **kwargs):
         self.mover_delivery_service = kwargs["mover_delivery_service"]
+        self.dds_delivery_service = kwargs["dds_service"]
         super(DeliveryStatusHandler, self).initialize(kwargs)
 
     @coroutine
     def get(self, delivery_order_id):
-        delivery_order = yield self.mover_delivery_service.update_delivery_status(delivery_order_id)
+        # Determine if project was delivered through dds or mover
+        dds_project_id = self.mover_delivery_service\
+            .get_delivery_order_by_id(delivery_order_id).dds_project_id
 
-        self.write_json({'id': delivery_order.id,
-                         'status': delivery_order.delivery_status.name,
-                         'mover_delivery_id': delivery_order.mover_delivery_id})
+        delivery_service = self.dds_delivery_service if dds_project_id else self.mover_delivery_service
+
+        delivery_order = yield delivery_service.update_delivery_status(delivery_order_id)
+
+        body = {
+                'id': delivery_order.id,
+                'status': delivery_order.delivery_status.name,
+                }
+        if dds_project_id:
+            body['dds_project_id'] = delivery_order.dds_project_id
+        else:
+            body['mover_delivery_id'] = delivery_order.mover_delivery_id
+
+        self.write_json(body)
         self.set_status(OK)

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -16,7 +16,8 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
     """
 
     def initialize(self, **kwargs):
-        self.mover_delivery_service = kwargs["mover_delivery_service"]
+        dds = self.body_as_object().get('dds', False)
+        self.delivery_service = kwargs["dds_service"] if dds else kwargs["mover_delivery_service"]
         super(DeliverByStageIdHandler, self).initialize(kwargs)
 
     @coroutine
@@ -35,7 +36,7 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
             log.debug("Will not skip running mover!")
             skip_mover = False
 
-        delivery_id = yield self.mover_delivery_service.deliver_by_staging_id(staging_id=staging_id,
+        delivery_id = yield self.delivery_service.deliver_by_staging_id(staging_id=staging_id,
                                                                               delivery_project=delivery_project_id,
                                                                               md5sum_file=md5sum_file,
                                                                               skip_mover=skip_mover)

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -112,6 +112,7 @@ class DeliveryOrder(SQLAlchemyBase):
     id = Column(Integer, primary_key=True, autoincrement=True)
     delivery_source = Column(String, nullable=False)
     delivery_project = Column(String, nullable=False)
+    dds_project_id = Column(String)
 
     # Optional path to md5sum file
     md5sum_file = Column(String)
@@ -131,7 +132,4 @@ class DeliveryOrder(SQLAlchemyBase):
     staging_order_id = Column(Integer)
 
     def __repr__(self):
-        return "Delivery order: {id: %s, source: %s, project: %s, status: %s }" % (str(self.id),
-                                                                                   self.delivery_source,
-                                                                                   self.delivery_project,
-                                                                                   self.delivery_status)
+        return f"Delivery order: {{id: {self.id}, source: {self.delivery_source}, project: {self.delivery_project}, status: {self.delivery_status}, dds_project_id: {self.dds_project_id} }}"

--- a/delivery/repositories/deliveries_repository.py
+++ b/delivery/repositories/deliveries_repository.py
@@ -57,12 +57,14 @@ class DatabaseBasedDeliveriesRepository(object):
                               delivery_project,
                               delivery_status,
                               staging_order_id,
+                              dds_project_id='',
                               md5sum_file=None):
         """
         Create a new delivery order and commit it to the database
         :param delivery_source: the source directory to be delivered
         :param delivery_project: the project code for the project to deliver to
         :param delivery_status: status of the delivery
+        :param dds_project_id: project id in DDS
         :param staging_order_id: NOTA BENE: this will need to be verified against the staging table before
                                  inserting it here, because at this point there is no validation that the
                                  value is valid!
@@ -72,6 +74,7 @@ class DatabaseBasedDeliveriesRepository(object):
         order = DeliveryOrder(delivery_source=delivery_source,
                               delivery_project=delivery_project,
                               delivery_status=delivery_status,
+                              dds_project_id=dds_project_id,
                               staging_order_id=staging_order_id,
                               md5sum_file=md5sum_file)
         self.session.add(order)

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -1,0 +1,137 @@
+import os.path
+import logging
+import re
+import json
+from tornado import gen
+
+from delivery.models.db_models import StagingStatus, DeliveryStatus
+from delivery.exceptions import ProjectNotFoundException, TooManyProjectsFound, InvalidStatusException
+
+log = logging.getLogger(__name__)
+
+
+class MoverDeliveryService(object):
+
+    def __init__(self, external_program_service, staging_service, delivery_repo, session_factory, dds_conf):
+        self.external_program_service = external_program_service
+        self.mover_external_program_service = self.external_program_service
+        self.moverinfo_external_program_service = self.external_program_service
+        self.staging_service = staging_service
+        self.delivery_repo = delivery_repo
+        self.session_factory = session_factory
+        self.dds_conf = dds_conf
+
+    @staticmethod
+    @gen.coroutine
+    def _run_mover(delivery_order_id, delivery_order_repo, external_program_service, session_factory, dds_conf):
+        session = session_factory()
+
+        # This is a somewhat hacky work-around to the problem that objects created in one
+        # thread, and thus associated with another session cannot be accessed by another
+        # thread, therefore it is re-materialized in here...
+        delivery_order = delivery_order_repo.get_delivery_order_by_id(delivery_order_id, session)
+        try:
+            cmd = [
+                    'dds',
+                    '-tp', dds_conf["token_path"],
+                    '-l', dds_conf["log_path"],
+                    'data', 'put',
+                    '--source', delivery_order.delivery_source,
+                    '-p', delivery_order.dds_project_id,
+                    '--silent',
+                    ]
+
+            log.debug("Running dds with cmd: {}".format(" ".join(cmd)))
+
+            execution = external_program_service.run(cmd)
+            delivery_order.delivery_status = DeliveryStatus.delivery_in_progress
+            delivery_order.mover_pid = execution.pid
+            session.commit()
+
+            execution_result = yield external_program_service.wait_for_execution(execution)
+
+            if execution_result.status_code == 0:
+                delivery_order.delivery_status = DeliveryStatus.delivery_successful
+                log.info(f"Successfully delivered: {delivery_order}")
+            else:
+                delivery_order.delivery_status = DeliveryStatus.delivery_failed
+                error_msg = f"Failed to deliver: {delivery_order}. DDS returned status code: {execution_result.status_code}"
+                log.error(error_msg)
+                raise RuntimeError(error_msg)
+
+        except Exception as e:
+            delivery_order.delivery_status = DeliveryStatus.delivery_failed
+            log.error(f"Failed to deliver: {delivery_order} because this exception was logged: {e}")
+            raise e
+        finally:
+            # Always commit the state change to the database
+            session.commit()
+
+    @staticmethod
+    @gen.coroutine
+    def _get_dds_project_id(delivery_project, external_program_service):
+        cmd = ['dds', 'project', 'ls', '--json']
+        execution = external_program_service.run(cmd)
+        execution_result = yield external_program_service.wait_for_execution(execution)
+
+        if execution_result.status_code == 0:
+            projects = [project
+                    for project in json.loads(execution_result.stdout)
+                    if project['Title'] == delivery_project]
+
+            if len(projects) == 1:
+                project_id = projects[0]['Project ID']
+                log.info(f"Fetched DDS project id for project {delivery_project}: {project_id}")
+                return project_id
+            elif len(projects) == 0:
+                error_msg = f"Project {delivery_project} could not be found in DDS."
+                log.error(error_msg)
+                raise ProjectNotFoundException(error_msg)
+            else:
+                error_msg = f"Multiple projects found with name {delivery_project}."
+                log.error(error_msg)
+                raise TooManyProjectsFound(error_msg)
+
+        else:
+            error_msg = f"Project {delivery_project} could not be found in DDS. DDS returned status code: {execution_result.status_code}, DDS stderr: {execution_result.stderr}"
+            log.error(error_msg)
+            raise ProjectNotFoundException(error_msg)
+
+    @gen.coroutine
+    def deliver_by_staging_id(self, staging_id, delivery_project, md5sum_file, skip_mover=False):
+
+        stage_order = self.staging_service.get_stage_order_by_id(staging_id)
+        if not stage_order or not stage_order.status == StagingStatus.staging_successful:
+            raise InvalidStatusException("Only deliver by staging_id if it has a successful status!"
+                                         "Staging order was: {}".format(stage_order))
+
+        if not skip_mover:
+            dds_project_id = yield MoverDeliveryService._get_dds_project_id(delivery_project, self.mover_external_program_service)
+        else:
+            dds_project_id = None
+
+        delivery_order = self.delivery_repo.create_delivery_order(delivery_source=stage_order.get_staging_path(),
+                                                                  delivery_project=delivery_project,
+                                                                  dds_project_id=dds_project_id,
+                                                                  delivery_status=DeliveryStatus.pending,
+                                                                  staging_order_id=staging_id,
+                                                                  md5sum_file=md5sum_file)
+
+        args_for_run_mover = {'delivery_order_id': delivery_order.id,
+                              'delivery_order_repo': self.delivery_repo,
+                              'external_program_service': self.mover_external_program_service,
+                              'session_factory': self.session_factory,
+                              'dds_conf': self.dds_conf
+                              }
+
+        if skip_mover:
+            session = self.session_factory()
+            delivery_order.delivery_status = DeliveryStatus.delivery_skipped
+            session.commit()
+        else:
+            yield MoverDeliveryService._run_mover(**args_for_run_mover)
+
+        return delivery_order.id
+
+    def get_delivery_order_by_id(self, delivery_order_id):
+        return self.delivery_repo.get_delivery_order_by_id(delivery_order_id)

--- a/delivery/services/mover_service.py
+++ b/delivery/services/mover_service.py
@@ -132,6 +132,9 @@ class MoverDeliveryService(object):
 
     @gen.coroutine
     def update_delivery_status(self, delivery_order_id):
+        """
+        Check delivery status and update the delivery database accordingly
+        """
         delivery_order = self.get_delivery_order_by_id(delivery_order_id)
 
         if delivery_order.mover_delivery_id and delivery_order.delivery_status == DeliveryStatus.delivery_in_progress:

--- a/requirements/dev
+++ b/requirements/dev
@@ -1,4 +1,4 @@
 -r prod
-mock==4.0
+mock==4.0.3
 nose==1.3.7
 

--- a/requirements/dev
+++ b/requirements/dev
@@ -1,4 +1,4 @@
 -r prod
-mock==2.0.0
+mock==4.0
 nose==1.3.7
 

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,6 +1,5 @@
-jsonpickle==0.9.2
-tornado==4.2.1
-sqlalchemy==1.1.3
-alembic==0.8.8
-enum34==1.1.6
+tornado==6.1
+sqlalchemy==1.4
+alembic==1.7
+enum34==1.1
 arteria==1.1.3

--- a/requirements/prod
+++ b/requirements/prod
@@ -1,5 +1,7 @@
+wheel==0.37.1
+jsonpickle==2.1
 tornado==6.1
-sqlalchemy==1.4
-alembic==1.7
-enum34==1.1
+sqlalchemy==1.4.35
+alembic==1.7.7
+enum34==1.1.10
 arteria==1.1.3

--- a/requirements/prod
+++ b/requirements/prod
@@ -4,4 +4,3 @@ sqlalchemy==1.1.3
 alembic==0.8.8
 enum34==1.1.6
 arteria==1.1.3
-

--- a/tests/integration_tests/test_integration.py
+++ b/tests/integration_tests/test_integration.py
@@ -200,12 +200,12 @@ class TestIntegration(AsyncHTTPTestCase):
                 self.assertEqual(project, "ABC_123")
 
                 status_response = yield self.http_client.fetch(link)
-                self.assertEquals(json.loads(status_response.body)["status"], StagingStatus.staging_successful.name)
+                self.assertEqual(json.loads(status_response.body)["status"], StagingStatus.staging_successful.name)
 
 
                 # The size of the fake project is 1024 bytes
                 status_response = yield self.http_client.fetch(link)
-                self.assertEquals(json.loads(status_response.body)["size"], 1024)
+                self.assertEqual(json.loads(status_response.body)["size"], 1024)
 
             staging_order_project_and_id = response_json.get("staging_order_ids")
 
@@ -218,7 +218,7 @@ class TestIntegration(AsyncHTTPTestCase):
                 delivery_link = delivery_resp_as_json['delivery_order_link']
 
                 status_response = yield self.http_client.fetch(delivery_link)
-                self.assertEquals(json.loads(status_response.body)["status"], DeliveryStatus.delivery_skipped.name)
+                self.assertEqual(json.loads(status_response.body)["status"], DeliveryStatus.delivery_skipped.name)
 
     def test_cannot_stage_the_same_runfolder_twice(self):
         # Note that this is a test which skips mover (since to_outbox is not expected to be installed on the system

--- a/tests/unit_tests/repositories/test_delivery_repository.py
+++ b/tests/unit_tests/repositories/test_delivery_repository.py
@@ -56,12 +56,14 @@ class TestDeliveryRepository(unittest.TestCase):
         actual = self.delivery_repo.create_delivery_order(delivery_source='/foo/source2',
                                                           delivery_project='bar2',
                                                           delivery_status=DeliveryStatus.pending,
+                                                          dds_project_id="snpseq00003",
                                                           staging_order_id=2)
 
         self.assertEqual(actual.id, 2)
         self.assertEqual(actual.delivery_source, '/foo/source2')
         self.assertEqual(actual.delivery_project, 'bar2')
         self.assertEqual(actual.delivery_status, DeliveryStatus.pending)
+        self.assertEqual(actual.dds_project_id, "snpseq00003")
         self.assertEqual(actual.staging_order_id, 2)
 
         # Check that the object has been committed, i.e. there are no 'dirty' objects in session

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -1,0 +1,148 @@
+
+import random
+from mock import MagicMock, create_autospec
+
+from tornado.testing import AsyncTestCase, gen_test
+from tornado.gen import coroutine
+
+from delivery.services.external_program_service import ExternalProgramService
+from delivery.services.dds_service import DDSService
+from delivery.models.db_models import DeliveryOrder, StagingOrder, StagingStatus, DeliveryStatus
+from delivery.models.execution import ExecutionResult, Execution
+from delivery.exceptions import InvalidStatusException, CannotParseMoverOutputException
+
+from tests.test_utils import MockIOLoop, assert_eventually_equals
+
+
+class TestDDSService(AsyncTestCase):
+
+    def setUp(self):
+
+        example_dds_project_ls_stdout = """[
+  {
+    "Last updated": "Thu, 03 Mar 2022 11:46:31 CET",
+    "PI": "Dungeon master",
+    "Project ID": "snpseq00001",
+    "Size": 26956752654,
+    "Status": "In Progress",
+    "Title": "Bullywug anatomy"
+  },
+  {
+    "Last updated": "Thu, 03 Mar 2022 10:34:05 CET",
+    "PI": "matas618",
+    "Project ID": "snpseq00002",
+    "Size": 0,
+    "Status": "In Progress",
+    "Title": "Site admins project"
+  }
+]
+        """
+
+
+        self.mock_mover_runner = create_autospec(ExternalProgramService)
+        mock_process = MagicMock()
+        mock_execution = Execution(pid=random.randint(1, 1000), process_obj=mock_process)
+        self.mock_mover_runner.run.return_value = mock_execution
+
+        @coroutine
+        def wait_as_coroutine(x):
+            return ExecutionResult(stdout=example_dds_project_ls_stdout, stderr="", status_code=0)
+
+        self.mock_mover_runner.wait_for_execution = wait_as_coroutine
+
+
+        self.mock_staging_service = MagicMock()
+        self.mock_delivery_repo = MagicMock()
+
+        self.delivery_order = DeliveryOrder(
+                id=1,
+                delivery_source="/foo",
+                delivery_project="Bullywug anatomy",
+                dds_project_id="snpseq00001",
+                )
+
+        self.mock_delivery_repo.create_delivery_order.return_value = self.delivery_order
+        self.mock_delivery_repo.get_delivery_order_by_id.return_value = self.delivery_order
+
+        self.mock_session_factory = MagicMock()
+        self.mock_dds_config = {'token_path': '/foo/bar/auth', 'log_path': '/foo/bar/log'}
+        self.mover_delivery_service = DDSService(external_program_service=None,
+                                                           staging_service=self.mock_staging_service,
+                                                           delivery_repo=self.mock_delivery_repo,
+                                                           session_factory=self.mock_session_factory,
+                                                           dds_conf=self.mock_dds_config)
+
+        # Inject separate external runner instances for the tests, since they need to return
+        # different information
+        self.mover_delivery_service.mover_external_program_service = self.mock_mover_runner
+
+        super(TestDDSService, self).setUp()
+
+    @gen_test
+    def test_deliver_by_staging_id(self):
+        staging_order = StagingOrder(source='/foo/bar', staging_target='/staging/dir/bar')
+        staging_order.status = StagingStatus.staging_successful
+        self.mock_staging_service.get_stage_order_by_id.return_value = staging_order
+
+        self.mock_staging_service.get_delivery_order_by_id.return_value = self.delivery_order
+
+        res = yield self.mover_delivery_service.deliver_by_staging_id(staging_id=1,
+                                                                      delivery_project='Bullywug anatomy',
+                                                                      md5sum_file='md5sum_file')
+
+        def _get_delivery_order():
+            return self.delivery_order.delivery_status
+        assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_successful)
+        self.mock_mover_runner.run.assert_called_with(['dds', '-tp', '/foo/bar/auth', '-l', '/foo/bar/log', 'data', 'put', '--source', '/foo', '-p', 'snpseq00001', '--silent'])
+
+    @gen_test
+    def test_deliver_by_staging_id_raises_on_non_existent_stage_id(self):
+        self.mock_staging_service.get_stage_order_by_id.return_value = None
+
+        with self.assertRaises(InvalidStatusException):
+
+            yield self.mover_delivery_service.deliver_by_staging_id(staging_id=1,
+                                                                    delivery_project='foo',
+                                                                    md5sum_file='md5sum_file')
+
+    @gen_test
+    def test_deliver_by_staging_id_raises_on_non_successful_stage_id(self):
+
+        staging_order = StagingOrder()
+        staging_order.status = StagingStatus.staging_failed
+        self.mock_staging_service.get_stage_order_by_id.return_value = staging_order
+
+        with self.assertRaises(InvalidStatusException):
+
+            yield self.mover_delivery_service.deliver_by_staging_id(staging_id=1,
+                                                                    delivery_project='foo',
+                                                                    md5sum_file='md5sum_file')
+
+    def test_delivery_order_by_id(self):
+        delivery_order = DeliveryOrder(id=1,
+                                       delivery_source='src',
+                                       delivery_project='xyz123',
+                                       delivery_status=DeliveryStatus.delivery_in_progress,
+                                       dds_project_id="dds1",
+                                       staging_order_id=11,
+                                       md5sum_file='file')
+        self.mock_delivery_repo.get_delivery_order_by_id.return_value = delivery_order
+        actual = self.mover_delivery_service.get_delivery_order_by_id(1)
+        self.assertEqual(actual.id, 1)
+
+    def test_possible_to_delivery_by_staging_id_and_skip_mover(self):
+
+        staging_order = StagingOrder(source='/foo/bar', staging_target='/staging/dir/bar')
+        staging_order.status = StagingStatus.staging_successful
+        self.mock_staging_service.get_stage_order_by_id.return_value = staging_order
+
+        self.mock_staging_service.get_delivery_order_by_id.return_value = self.delivery_order
+
+        self.mover_delivery_service.deliver_by_staging_id(staging_id=1,
+                                                          delivery_project='Bullywug anatomy',
+                                                          md5sum_file='md5sum_file',
+                                                          skip_mover=True)
+
+        def _get_delivery_order():
+            return self.delivery_order.delivery_status
+        assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_skipped)


### PR DESCRIPTION
**What problems does this PR solve?**
We are moving away from the `mover` delivery service to the new DDS service. Makes it possible to deliver data with either service by setting the `dds` flag to true when sending a delivery request. In principle this should not affect the old delivery workflow in anyways.

Support of `mover` will be removed after it has been decommissioned. 

**How has the changes been tested?**
The existing tests to `mover` have been adapted to test DDS in the same way. However, because we didn't have access to the DDS test environment at the time, these changes have not be tested against the DDS command line interface. This should be tested in staging with the DDS test environment.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
