### PR TITLE
Implement create project endpoint

### DIFF
--- a/alembic/versions/85082f64ccd0_add_dds_project_table.py
+++ b/alembic/versions/85082f64ccd0_add_dds_project_table.py
@@ -1,0 +1,26 @@
+"""add dds_project_table
+
+Revision ID: 85082f64ccd0
+Revises: ea812cd3ab7b
+Create Date: 2022-05-11 13:15:55.389832
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '85082f64ccd0'
+down_revision = 'ea812cd3ab7b'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table('dds_projects',
+            sa.Column('project_name', sa.String, nullable=False, primary_key=True),
+            sa.Column('dds_project_id', sa.String),
+            )
+
+
+def downgrade():
+    op.drop_table('dds_projects')

--- a/alembic/versions/85082f64ccd0_add_dds_project_table.py
+++ b/alembic/versions/85082f64ccd0_add_dds_project_table.py
@@ -17,8 +17,8 @@ depends_on = None
 
 def upgrade():
     op.create_table('dds_projects',
-            sa.Column('project_name', sa.String, nullable=False, primary_key=True),
-            sa.Column('dds_project_id', sa.String),
+            sa.Column('dds_project_id', sa.String, nullable=False, primary_key=True),
+            sa.Column('project_name', sa.String),
             )
 
 

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -15,6 +15,7 @@ from delivery.handlers.utility_handlers import VersionHandler
 from delivery.handlers.runfolder_handlers import RunfolderHandler
 from delivery.handlers.project_handlers import ProjectHandler, ProjectsForRunfolderHandler, \
     BestPracticeProjectSampleHandler
+from delivery.handlers.dds_handlers import DDSCreateProjectHandler
 from delivery.handlers.delivery_handlers import DeliverByStageIdHandler, DeliveryStatusHandler
 from delivery.handlers.staging_handlers import StagingRunfolderHandler, StagingHandler,\
     StageGeneralDirectoryHandler, StagingProjectRunfoldersHandler
@@ -24,7 +25,7 @@ from delivery.repositories.runfolder_repository import FileSystemBasedRunfolderR
     FileSystemBasedUnorganisedRunfolderRepository
 from delivery.repositories.staging_repository import DatabaseBasedStagingRepository
 from delivery.repositories.deliveries_repository import DatabaseBasedDeliveriesRepository
-from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository
+from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository, DDSProjectRepository
 from delivery.repositories.delivery_sources_repository import DatabaseBasedDeliverySourcesRepository
 from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 
@@ -75,6 +76,8 @@ def routes(**kwargs):
         url(r"/api/1.0/deliver/status/(.+)", DeliveryStatusHandler,
             name="delivery_status", kwargs=kwargs),
 
+        url(r"/api/1.0/dds_project/create/(.+)", DDSCreateProjectHandler,
+            name="create_dds_project", kwargs=kwargs),
     ]
 
 
@@ -161,9 +164,11 @@ def compose_application(config):
                                                   path_to_mover=path_to_mover)
 
     dds_conf = config['dds_conf']
+    dds_project_repo = DDSProjectRepository(session_factory=session_factory)
     dds_service = DDSService(external_program_service=external_program_service,
                                                   staging_service=staging_service,
                                                   delivery_repo=delivery_repo,
+                                                  dds_project_repo=dds_project_repo,
                                                   session_factory=session_factory,
                                                   dds_conf=dds_conf)
 

--- a/delivery/exceptions.py
+++ b/delivery/exceptions.py
@@ -84,3 +84,9 @@ class ProjectsDirNotfoundException(Exception):
     Should be raised when a directory containing projects could not be found
     """
     pass
+
+class CannotParseDDSOutputException(Exception):
+    """
+    Should be raised when DDS's output cannot be parsed for e.g. creating a project.
+    """
+    pass

--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -1,6 +1,10 @@
 from tornado.gen import coroutine
 
+from delivery.handlers import *
 from delivery.handlers.utility_handlers import ArteriaDeliveryBaseHandler
+
+import logging
+log = logging.getLogger(__name__)
 
 class DDSProjectBaseHandler(ArteriaDeliveryBaseHandler):
     """
@@ -8,7 +12,6 @@ class DDSProjectBaseHandler(ArteriaDeliveryBaseHandler):
     """
 
     def initialize(self, **kwargs):
-        self.dds_project_repo = kwargs["dds_project_repo"]
         self.dds_service = kwargs["dds_service"]
         super(DDSProjectBaseHandler, self).initialize(kwargs)
 
@@ -39,7 +42,8 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
             response = requests.request("POST", url, json=payload)
         """
 
-        project_metadata = self.body_as_object()
+        required_members = ["token_path"]
+        project_metadata = self.body_as_object(required_members=required_members)
 
         await self.dds_service.create_dds_project(project_name, project_metadata)
         self.set_status(ACCEPTED)

--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -1,0 +1,45 @@
+from tornado.gen import coroutine
+
+from delivery.handlers.utility_handlers import ArteriaDeliveryBaseHandler
+
+class DDSProjectBaseHandler(ArteriaDeliveryBaseHandler):
+    """
+    Manage DDS projects
+    """
+
+    def initialize(self, **kwargs):
+        self.dds_project_repo = kwargs["dds_project_repo"]
+        self.dds_service = kwargs["dds_service"]
+        super(DDSProjectBaseHandler, self).initialize(kwargs)
+
+class DDSCreateProjectHandler(DDSProjectBaseHandler):
+    """
+    Manage DDS projects
+    """
+
+    async def post(self, project_name):
+        """
+        Create a new project in DDS. The project description as well as the
+        email of its pi must be specified in the request body. Project owners,
+        researchers, and whether the data is sensitive or not (default is yes),
+        can also be specified there. E.g.:
+
+            import requests
+
+            url = "http://localhost:8080/api/1.0/dds_project/create/AB-1234"
+
+            payload = {
+                "description": "Dummy project",
+                "pi": "alex@doe.com",
+                "researchers": ["robin@doe.com", "kim@doe.com"],
+                "owners": ["alex@doe.com"],
+                "non-sensitive": False,
+            }
+
+            response = requests.request("POST", url, json=payload)
+        """
+
+        project_metadata = self.body_as_object()
+
+        await self.dds_service.create_dds_project(project_name, project_metadata)
+        self.set_status(ACCEPTED)

--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -45,5 +45,7 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
         required_members = ["token_path"]
         project_metadata = self.body_as_object(required_members=required_members)
 
-        await self.dds_service.create_dds_project(project_name, project_metadata)
+        dds_project_id = await self.dds_service.create_dds_project(project_name, project_metadata)
+
         self.set_status(ACCEPTED)
+        self.write_json({'dds_project_id': dds_project_id})

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -43,11 +43,16 @@ class DDSProject(SQLAlchemyBase):
     Keeps track of project names and project IDs in DDS
     """
     __tablename__ = 'dds_projects'
-    project_name = Column(String, nullable=False, primary_key=True)
-    dds_project_id = Column(String)
+    dds_project_id = Column(String, nullable=False, primary_key=True)
+    project_name = Column(String)
 
     def __repr__(self):
-        return f"DDS Project: {{project_name: {self.project_name}, dds_project_id: {self.dds_project_id} }}"
+        return (
+                "DDS Project: { "
+                f"dds_project_id: {self.dds_project_id}, "
+                f"project_name: {self.project_name} "
+                "}"
+                )
 
 
 class StagingStatus(base_enum.Enum):

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -37,6 +37,19 @@ class DeliverySource(SQLAlchemyBase):
                 self.path,
                 self.batch)
 
+
+class DDSProject(SQLAlchemyBase):
+    """
+    Keeps track of project names and project IDs in DDS
+    """
+    __tablename__ = 'dds_projects'
+    project_name = Column(String, nullable=False, primary_key=True)
+    dds_project_id = Column(String)
+
+    def __repr__(self):
+        return f"DDS Project: {{project_name: {self.project_name}, dds_project_id: {self.dds_project_id} }}"
+
+
 class StagingStatus(base_enum.Enum):
     """
     Enumerate possible staging statuses

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -5,11 +5,49 @@ import os
 from delivery.services.file_system_service import FileSystemService
 from delivery.services.metadata_service import MetadataService
 from delivery.models.project import GeneralProject, RunfolderProject
+from delivery.models.db_models import DDSProject
 from delivery.models.runfolder import RunfolderFile
 from delivery.exceptions import TooManyProjectsFound, ProjectNotFoundException, ProjectReportNotFoundException, \
     ProjectsDirNotfoundException
 
 log = logging.getLogger(__name__)
+
+
+class DDSProjectRepository:
+    """
+    A repository of DDS projects backed by a database.
+    """
+
+    def __init__(self, session_factory):
+        """
+        Instantiate a new DDSProjectRepository
+        :param session_factory: factory method which can produce new sqlalchemy Session objects
+        """
+        self.session = session_factory()
+
+    def get_dds_project_by_name(self, project_name):
+        """
+        Get DDS project by Clarity project name
+        :param project_name: Clarity project name to look for
+        :return: the associated DDS project id
+        """
+        return self.session.query(DDSProject)\
+                .filter(DDSProject.project_name == project_name)\
+                .one()
+
+    def create_dds_project(self, project_name, dds_project_id):
+        """
+        Add a DDS project and commit it to the database
+        :param project_name: Clarity project name
+        :param dds_project_id: DDS project id
+
+        :return: DDSProject
+        """
+        dds_project = DDSProject(project_name=project_name, dds_project_id=dds_project_id)
+        self.session.add(dds_project)
+        self.session.commit()
+
+        return dds_project
 
 
 class GeneralProjectRepository(object):

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -25,6 +25,17 @@ class DDSProjectRepository:
         """
         self.session = session_factory()
 
+    def project_exists(self, project_name):
+        """
+        Check if project exists in the database
+        :param project_name: Clarity project name
+        :return: Bool
+        """
+        return self.session.query(DDSProject)\
+                .filter(DDSProject.project_name == project_name)\
+                .count() >= 1
+
+
     def get_dds_project_by_name(self, project_name):
         """
         Get DDS project by Clarity project name
@@ -35,7 +46,7 @@ class DDSProjectRepository:
                 .filter(DDSProject.project_name == project_name)\
                 .one()
 
-    def create_dds_project(self, project_name, dds_project_id):
+    def add_dds_project(self, project_name, dds_project_id):
         """
         Add a DDS project and commit it to the database
         :param project_name: Clarity project name

--- a/delivery/repositories/project_repository.py
+++ b/delivery/repositories/project_repository.py
@@ -25,36 +25,15 @@ class DDSProjectRepository:
         """
         self.session = session_factory()
 
-    def project_exists(self, project_name):
-        """
-        Check if project exists in the database
-        :param project_name: Clarity project name
-        :return: Bool
-        """
-        return self.session.query(DDSProject)\
-                .filter(DDSProject.project_name == project_name)\
-                .count() >= 1
-
-
-    def get_dds_project_by_name(self, project_name):
-        """
-        Get DDS project by Clarity project name
-        :param project_name: Clarity project name to look for
-        :return: the associated DDS project id
-        """
-        return self.session.query(DDSProject)\
-                .filter(DDSProject.project_name == project_name)\
-                .one()
-
-    def add_dds_project(self, project_name, dds_project_id):
+    def add_dds_project(self, dds_project_id, project_name):
         """
         Add a DDS project and commit it to the database
-        :param project_name: Clarity project name
         :param dds_project_id: DDS project id
+        :param project_name: Clarity project name
 
         :return: DDSProject
         """
-        dds_project = DDSProject(project_name=project_name, dds_project_id=dds_project_id)
+        dds_project = DDSProject(dds_project_id=dds_project_id, project_name=project_name)
         self.session.add(dds_project)
         self.session.commit()
 

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -32,7 +32,7 @@ class DDSService(object):
     @staticmethod
     def _parse_dds_project_id(dds_output):
         log.debug('DDS output was: {}'.format(dds_output))
-        pattern = re.compile('Project created with id: (snpseq\d+)')
+        pattern = re.compile(r'Project created with id: (snpseq\d+)')
         hits = pattern.search(dds_output)
         if hits:
             return hits.group(1)

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -40,8 +40,6 @@ class DDSService(object):
             raise CannotParseDDSOutputException(f"Could not parse DDS project ID from: {dds_output}")
 
     async def create_dds_project(self, project_name, project_metadata):
-        assert not self.dds_project_repo.project_exists(project_name)
-
         cmd = [
                 'dds',
                 '--token-path', self.dds_conf["token_path"],

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -40,6 +40,14 @@ class DDSService(object):
             raise CannotParseDDSOutputException(f"Could not parse DDS project ID from: {dds_output}")
 
     async def create_dds_project(self, project_name, project_metadata):
+        """
+        Create a new project in dds
+        :param project_name: Project name from Clarity
+        :param project_metadata: dictionnary containing pi email, project
+        description, owner and researcher emails as well as whether the data is
+        sensitive or not.
+        :return: project id in dds
+        """
         cmd = [
                 'dds',
                 '--token-path', project_metadata["token_path"],
@@ -65,7 +73,7 @@ class DDSService(object):
                 for args in ['--researcher', researcher]
                 ]
 
-        if project_metadata.get('--non-sensitive', False):
+        if project_metadata.get('non-sensitive', False):
             cmd += ['--non-sensitive']
 
         log.debug(f"Running dds with command: {' '.join(cmd)}")
@@ -81,6 +89,8 @@ class DDSService(object):
         self.dds_project_repo.add_dds_project(
                 project_name=project_name,
                 dds_project_id=dds_project_id)
+
+        return dds_project_id
 
     @staticmethod
     @gen.coroutine

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -42,7 +42,7 @@ class DDSService(object):
     async def create_dds_project(self, project_name, project_metadata):
         cmd = [
                 'dds',
-                '--token-path', self.dds_conf["token_path"],
+                '--token-path', project_metadata["token_path"],
                 '--log-file', self.dds_conf["log_path"],
                 ]
 
@@ -68,8 +68,8 @@ class DDSService(object):
         if project_metadata.get('--non-sensitive', False):
             cmd += ['--non-sensitive']
 
-        log.debug("Running dds with command: {' '.join(cmd)}")
-        execution_result = self.external_program_service.run_and_wait(cmd)
+        log.debug(f"Running dds with command: {' '.join(cmd)}")
+        execution_result = await self.external_program_service.run_and_wait(cmd)
 
         if execution_result.status_code == 0:
             dds_project_id = DDSService._parse_dds_project_id(execution_result.stdout)
@@ -78,7 +78,9 @@ class DDSService(object):
             log.error(error_msg)
             raise RuntimeError(error_msg)
 
-        self.dds_project_repo.add_dds_project(project_name, dds_project_id)
+        self.dds_project_repo.add_dds_project(
+                project_name=project_name,
+                dds_project_id=dds_project_id)
 
     @staticmethod
     @gen.coroutine

--- a/delivery/services/staging_service.py
+++ b/delivery/services/staging_service.py
@@ -112,13 +112,13 @@ class StagingService(object):
                 log.info("Successfully staged: {} to: {}".format(staging_order, staging_order.get_staging_path()))
             else:
                 staging_order.status = StagingStatus.staging_failed
-                log.info("Failed in staging: {} because rsync returned exit code: {}".
+                log.error("Failed in staging: {} because rsync returned exit code: {}".
                          format(staging_order, execution_result.status_code))
 
         # TODO Better exception handling here...
         except Exception as e:
             staging_order.status = StagingStatus.staging_failed
-            log.info("Failed in staging: {} because this exception was logged: {}".
+            log.error("Failed in staging: {} because this exception was logged: {}".
                      format(staging_order, e))
         finally:
             # Always commit the state change to the database

--- a/requirements/prod
+++ b/requirements/prod
@@ -5,3 +5,4 @@ sqlalchemy==1.4.35
 alembic==1.7.7
 enum34==1.1.10
 arteria==1.1.3
+dds-cli==1.0.5

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -222,6 +222,7 @@ class TestIntegrationDDS(BaseIntegration):
                 body=json.dumps(payload))
 
         self.assertEqual(response.code, 202)
+        self.assertTrue(json.loads(response.body)["dds_project_id"].startswith("snpseq"))
 
     @gen_test
     def test_can_create_two_projects(self):
@@ -240,11 +241,15 @@ class TestIntegrationDDS(BaseIntegration):
                 self.get_url(url), method='POST',
                 body=json.dumps(payload))
         self.assertEqual(response.code, 202)
+        dds_project_id1 = json.loads(response.body)["dds_project_id"]
 
         response = yield self.http_client.fetch(
                 self.get_url(url), method='POST',
                 body=json.dumps(payload))
         self.assertEqual(response.code, 202)
+        dds_project_id2 = json.loads(response.body)["dds_project_id"]
+
+        self.assertNotEqual(dds_project_id1, dds_project_id2)
 
 
 class TestIntegrationDDSLongWait(BaseIntegration):

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -1,10 +1,10 @@
-
-
 import json
 from functools import partial
 import sys
 import time
 import tempfile
+
+import mock
 
 from tornado.testing import *
 from tornado.web import Application
@@ -14,6 +14,7 @@ from arteria.web.app import AppService
 from delivery.app import routes as app_routes, compose_application
 from delivery.models.db_models import StagingStatus, DeliveryStatus
 from delivery.services.metadata_service import MetadataService
+from delivery.services.external_program_service import ExternalProgramService
 
 from tests.integration_tests.base import BaseIntegration
 from tests.test_utils import assert_eventually_equals, unorganised_runfolder, samplesheet_file_from_runfolder, \
@@ -246,3 +247,21 @@ class TestIntegrationDDS(BaseIntegration):
 
                 staging_response = yield self.http_client.fetch(staging_status_links["ABC_123"])
                 self.assertEqual(json.loads(staging_response.body)["status"], StagingStatus.staging_successful.name)
+
+    @gen_test
+    def test_can_create_project(self):
+        return
+        project_name = "CD-1234"
+        url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+        payload = {
+            "description": "Dummy project",
+            "pi": "alex@doe.com",
+            "researchers": ["robin@doe.com", "kim@doe.com"],
+            "owners": ["alex@doe.com"],
+            "non-sensitive": False,
+        }
+        response = yield self.http_client.fetch(
+                self.get_url(url), method='POST',
+                body=json.dumps(payload))
+
+        self.assertEqual(response.code, 202)

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -205,6 +205,55 @@ class TestIntegrationDDS(BaseIntegration):
                 self.assertEqual(json.loads(status_response.body)["status"], StagingStatus.staging_successful.name)
 
     @gen_test
+    def test_can_create_project(self):
+        project_name = "CD-1234"
+        url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+        payload = {
+            "description": "Dummy project",
+            "pi": "alex@doe.com",
+            "researchers": ["robin@doe.com", "kim@doe.com"],
+            "owners": ["alex@doe.com"],
+            "non-sensitive": False,
+            "token_path": '/foo/bar/auth',
+        }
+
+        response = yield self.http_client.fetch(
+                self.get_url(url), method='POST',
+                body=json.dumps(payload))
+
+        self.assertEqual(response.code, 202)
+
+    @gen_test
+    def test_can_create_two_projects(self):
+        project_name = "CD-1234"
+        url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+        payload = {
+            "description": "Dummy project",
+            "pi": "alex@doe.com",
+            "researchers": ["robin@doe.com", "kim@doe.com"],
+            "owners": ["alex@doe.com"],
+            "non-sensitive": False,
+            "token_path": '/foo/bar/auth',
+        }
+
+        response = yield self.http_client.fetch(
+                self.get_url(url), method='POST',
+                body=json.dumps(payload))
+        self.assertEqual(response.code, 202)
+
+        response = yield self.http_client.fetch(
+                self.get_url(url), method='POST',
+                body=json.dumps(payload))
+        self.assertEqual(response.code, 202)
+
+
+class TestIntegrationDDSLongWait(BaseIntegration):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.mock_duration = 10
+
+    @gen_test
     def test_can_deliver_and_respond(self):
         with tempfile.TemporaryDirectory(dir='./tests/resources/runfolders/', prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
 
@@ -248,20 +297,3 @@ class TestIntegrationDDS(BaseIntegration):
                 staging_response = yield self.http_client.fetch(staging_status_links["ABC_123"])
                 self.assertEqual(json.loads(staging_response.body)["status"], StagingStatus.staging_successful.name)
 
-    @gen_test
-    def test_can_create_project(self):
-        return
-        project_name = "CD-1234"
-        url = "/".join([self.API_BASE, "dds_project", "create", project_name])
-        payload = {
-            "description": "Dummy project",
-            "pi": "alex@doe.com",
-            "researchers": ["robin@doe.com", "kim@doe.com"],
-            "owners": ["alex@doe.com"],
-            "non-sensitive": False,
-        }
-        response = yield self.http_client.fetch(
-                self.get_url(url), method='POST',
-                body=json.dumps(payload))
-
-        self.assertEqual(response.code, 202)

--- a/tests/unit_tests/repositories/test_project_repository.py
+++ b/tests/unit_tests/repositories/test_project_repository.py
@@ -42,14 +42,18 @@ class TestDDSProjectRepository(unittest.TestCase):
         # Prep the repo
         self.dds_project_repo = DDSProjectRepository(session_factory)
 
+    def test_project_exists(self):
+        self.assertTrue(self.dds_project_repo.project_exists("CD-1234"))
+        self.assertFalse(self.dds_project_repo.project_exists("IJ-6666"))
+
     def test_get_dds_project_by_name(self):
         actual = self.dds_project_repo\
                 .get_dds_project_by_name(self.dds_project_1.project_name)
         self.assertEqual(actual.dds_project_id, actual.dds_project_id)
 
-    def test_create_dds_project(self):
+    def test_add_dds_project(self):
         dds_project = self.dds_project_repo\
-                .create_dds_project(project_name="GH-9012", dds_project_id="snpseq00003")
+                .add_dds_project(project_name="GH-9012", dds_project_id="snpseq00003")
 
         self.assertIsInstance(dds_project, DDSProject)
         self.assertEqual(dds_project.project_name, "GH-9012")

--- a/tests/unit_tests/repositories/test_project_repository.py
+++ b/tests/unit_tests/repositories/test_project_repository.py
@@ -3,14 +3,63 @@ import os
 import mock
 import unittest
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from delivery.exceptions import ProjectReportNotFoundException
 from delivery.models.project import GeneralProject, RunfolderProject
-from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository
+from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository, DDSProjectRepository
+from delivery.models.db_models import SQLAlchemyBase, DDSProject
 from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
 from delivery.services.file_system_service import FileSystemService
 from delivery.services.metadata_service import MetadataService
 
 from tests.test_utils import UNORGANISED_RUNFOLDER
+
+
+class TestDDSProjectRepository(unittest.TestCase):
+    def setUp(self):
+        # NOTE setting echo to true is very useful to se which sql statements get
+        # executed, but since it fills up the logs a lot it's been disabled by
+        # default here.
+        engine = create_engine('sqlite:///:memory:', echo=False)
+        SQLAlchemyBase.metadata.create_all(engine)
+
+        # Throw some data into the in-memory db
+        session_factory = sessionmaker()
+        session_factory.configure(bind=engine)
+
+        self.session = session_factory()
+
+        self.dds_project_1 = DDSProject(project_name="CD-1234", dds_project_id="snpseq00001")
+        self.session.add(self.dds_project_1)
+
+        self.dds_project_2 = DDSProject(project_name="EF-5678", dds_project_id="snpseq00002")
+        self.session.add(self.dds_project_2)
+
+        self.session.commit()
+
+        # Prep the repo
+        self.dds_project_repo = DDSProjectRepository(session_factory)
+
+    def test_get_dds_project_by_name(self):
+        actual = self.dds_project_repo\
+                .get_dds_project_by_name(self.dds_project_1.project_name)
+        self.assertEqual(actual.dds_project_id, actual.dds_project_id)
+
+    def test_create_dds_project(self):
+        dds_project = self.dds_project_repo\
+                .create_dds_project(project_name="GH-9012", dds_project_id="snpseq00003")
+
+        self.assertIsInstance(dds_project, DDSProject)
+        self.assertEqual(dds_project.project_name, "GH-9012")
+        self.assertEqual(dds_project.dds_project_id, "snpseq00003")
+
+        # Check that the object has been committed, i.e. there are no 'dirty' objects in session
+        self.assertEqual(len(self.session.dirty), 0)
+        project_from_session = self.session.query(
+            DDSProject).filter(DDSProject.project_name == dds_project.project_name).one()
+        self.assertEqual(project_from_session.dds_project_id, dds_project.dds_project_id)
 
 
 class TestGeneralProjectRepository(unittest.TestCase):

--- a/tests/unit_tests/repositories/test_project_repository.py
+++ b/tests/unit_tests/repositories/test_project_repository.py
@@ -42,15 +42,6 @@ class TestDDSProjectRepository(unittest.TestCase):
         # Prep the repo
         self.dds_project_repo = DDSProjectRepository(session_factory)
 
-    def test_project_exists(self):
-        self.assertTrue(self.dds_project_repo.project_exists("CD-1234"))
-        self.assertFalse(self.dds_project_repo.project_exists("IJ-6666"))
-
-    def test_get_dds_project_by_name(self):
-        actual = self.dds_project_repo\
-                .get_dds_project_by_name(self.dds_project_1.project_name)
-        self.assertEqual(actual.dds_project_id, actual.dds_project_id)
-
     def test_add_dds_project(self):
         dds_project = self.dds_project_repo\
                 .add_dds_project(project_name="GH-9012", dds_project_id="snpseq00003")

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -183,8 +183,6 @@ project"""
 
     @gen_test
     def test_create_project(self):
-        self.mock_dds_project_repo.project_exists.return_value = False
-
         project_name = "AA-1221"
         project_metadata = {
                 "description": "Dummy project",

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -65,15 +65,17 @@ class TestDDSService(AsyncTestCase):
 
         self.mock_session_factory = MagicMock()
         self.mock_dds_config = {'token_path': '/foo/bar/auth', 'log_path': '/foo/bar/log'}
-        self.mover_delivery_service = DDSService(external_program_service=None,
-                                                           staging_service=self.mock_staging_service,
-                                                           delivery_repo=self.mock_delivery_repo,
-                                                           session_factory=self.mock_session_factory,
-                                                           dds_conf=self.mock_dds_config)
+        self.dds_service = DDSService(
+                external_program_service=None,
+                staging_service=self.mock_staging_service,
+                delivery_repo=self.mock_delivery_repo,
+                session_factory=self.mock_session_factory,
+                dds_conf=self.mock_dds_config
+                )
 
         # Inject separate external runner instances for the tests, since they need to return
         # different information
-        self.mover_delivery_service.mover_external_program_service = self.mock_mover_runner
+        self.dds_service.mover_external_program_service = self.mock_mover_runner
 
         super(TestDDSService, self).setUp()
 
@@ -88,7 +90,7 @@ class TestDDSService(AsyncTestCase):
         self.mock_staging_service.get_delivery_order_by_id.return_value = self.delivery_order
 
         with patch('shutil.rmtree') as mock_rmtree:
-            res = yield self.mover_delivery_service.deliver_by_staging_id(
+            res = yield self.dds_service.deliver_by_staging_id(
                     staging_id=1,
                     delivery_project='snpseq00001',
                     token_path='token_path',
@@ -106,7 +108,7 @@ class TestDDSService(AsyncTestCase):
 
         with self.assertRaises(InvalidStatusException):
 
-            yield self.mover_delivery_service.deliver_by_staging_id(
+            yield self.dds_service.deliver_by_staging_id(
                     staging_id=1,
                     delivery_project='snpseq00001',
                     md5sum_file='md5sum_file',
@@ -122,7 +124,7 @@ class TestDDSService(AsyncTestCase):
 
         with self.assertRaises(InvalidStatusException):
 
-            yield self.mover_delivery_service.deliver_by_staging_id(
+            yield self.dds_service.deliver_by_staging_id(
                     staging_id=1,
                     delivery_project='snpseq00001',
                     md5sum_file='md5sum_file',
@@ -137,7 +139,7 @@ class TestDDSService(AsyncTestCase):
                                        staging_order_id=11,
                                        md5sum_file='file')
         self.mock_delivery_repo.get_delivery_order_by_id.return_value = delivery_order
-        actual = self.mover_delivery_service.get_delivery_order_by_id(1)
+        actual = self.dds_service.get_delivery_order_by_id(1)
         self.assertEqual(actual.id, 1)
 
     def test_possible_to_delivery_by_staging_id_and_skip_mover(self):
@@ -148,7 +150,7 @@ class TestDDSService(AsyncTestCase):
 
         self.mock_staging_service.get_delivery_order_by_id.return_value = self.delivery_order
 
-        self.mover_delivery_service.deliver_by_staging_id(
+        self.dds_service.deliver_by_staging_id(
                 staging_id=1,
                 delivery_project='snpseq00001',
                 md5sum_file='md5sum_file',

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -209,9 +209,3 @@ project"""
                     .assert_called_once_with(
                             project_name,
                             mock_parse_dds_project_id.return_value)
-
-    @gen_test
-    def test_cannot_create_if_project_exists(self):
-        self.mock_dds_project_repo.project_exists.return_value = True
-        with self.assertRaises(AssertionError):
-            yield self.dds_service.create_dds_project("AA-1111", {})


### PR DESCRIPTION
**What problems does this PR solve?**
During a delivery workflow, we need to create a project in DDS. This PR adds an endpoint in the API to create such a project, as well as a new table in the database to keep track of the correspondence between DDS project ids and projects in Clarity.

**How has the changes been tested?**
Unit and integration tests have been added. Creating a project in DDS have been successfully tested locally. Testing in staging with the last DDS release will be performed after a new version of arteria-delivery is released.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be initiated.

  - [ ] This PR contains code that could remove data
