### PR TITLE
Use `--mount-dir` in dds data pput

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -11,4 +11,5 @@ project_links_directory: /tmp/
 path_to_mover: '/usr/local/mover/1.0.0/'
 dds_conf:
   log_path: dds.log
+  mount_dir: /tmp/
 port: 9999

--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -37,6 +37,7 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
                 "researchers": ["robin@doe.com", "kim@doe.com"],
                 "owners": ["alex@doe.com"],
                 "non-sensitive": False,
+                "token_path": "/foo/bar"
             }
 
             response = requests.request("POST", url, json=payload)

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -110,6 +110,7 @@ class DDSService(object):
 
             cmd += [
                     'data', 'put',
+                    '--mount-dir', dds_conf["mount_dir"],
                     '--source', delivery_order.delivery_source,
                     '--project', delivery_order.delivery_project,
                     '--silent',

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -57,7 +57,7 @@ class DDSService(object):
         cmd += [
                 'project', 'create',
                 '--title', project_name,
-                '--description', project_metadata['description'],
+                '--description', f"\"{project_metadata['description']}\"",
                 '-pi',  project_metadata['pi']
                 ]
 

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -209,7 +209,7 @@ project"""
                 '--log-file', '/foo/bar/log',
                 'project', 'create',
                 '--title', project_name,
-                '--description', project_metadata['description'],
+                '--description', f'"{project_metadata["description"]}"',
                 '-pi', project_metadata['pi'],
                 '--owner', project_metadata['owners'][0],
                 '--researcher', project_metadata['researchers'][0],

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -65,7 +65,10 @@ class TestDDSService(AsyncTestCase):
         self.mock_delivery_repo.get_delivery_order_by_id.return_value = self.delivery_order
 
         self.mock_session_factory = MagicMock()
-        self.mock_dds_config = {'token_path': '/foo/bar/auth', 'log_path': '/foo/bar/log'}
+        self.mock_dds_config = {
+                'log_path': '/foo/bar/log',
+                'mount_dir': '/foo/bar/mount_dir',
+                }
         self.dds_service = DDSService(
                 external_program_service=ExternalProgramService(),
                 staging_service=self.mock_staging_service,
@@ -107,6 +110,7 @@ class TestDDSService(AsyncTestCase):
             '--token-path', 'token_path',
             '--log-file', '/foo/bar/log',
             'data', 'put',
+            '--mount-dir', '/foo/bar/mount_dir',
             '--source', '/staging/dir/bar',
             '--project', 'snpseq00001',
             '--silent'


### PR DESCRIPTION
**What problems does this PR solve?**
When uploading data, DDS will create its own staging directory. By default, this directory goes into the CWD but we suspect `funk004` does not have the permission to write there on Miarka.

This PR makes it possible to specify where this directory is created.

Additionally, it fixes a small bug by putting quotes around the project description in the call to `dds project create`.

**How has the changes been tested?**
Unit tests have been adapted and more tests will be performed in staging.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
