### PR TITLE
Get authentication token through API

### DIFF
--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -3,6 +3,8 @@ from tornado.gen import coroutine
 from delivery.handlers import *
 from delivery.handlers.utility_handlers import ArteriaDeliveryBaseHandler
 
+import os
+import tempfile
 import logging
 log = logging.getLogger(__name__)
 
@@ -25,7 +27,8 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
         Create a new project in DDS. The project description as well as the
         email of its pi must be specified in the request body. Project owners,
         researchers, and whether the data is sensitive or not (default is yes),
-        can also be specified there. E.g.:
+        can also be specified there. "auth_token" can be either the path to
+        the authentication token or the token itself. E.g.:
 
             import requests
 
@@ -44,9 +47,23 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
         """
 
         required_members = ["auth_token"]
-        project_metadata = self.body_as_object(required_members=required_members)
+        project_metadata = self.body_as_object(
+                required_members=required_members)
 
-        dds_project_id = await self.dds_service.create_dds_project(project_name, project_metadata)
+        with tempfile.NamedTemporaryFile(mode='w', delete=True) as token_file:
+            if os.path.exists(project_metadata["auth_token"]):
+                token_path = project_metadata["auth_token"]
+            else:
+                token_file.write(project_metadata["auth_token"])
+                token_file.flush()
+
+                token_path = token_file.name
+
+            dds_project_id = await self.dds_service.create_dds_project(
+                    project_name,
+                    project_metadata,
+                    token_path,
+                    )
 
         self.set_status(ACCEPTED)
         self.write_json({'dds_project_id': dds_project_id})

--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -37,13 +37,13 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
                 "researchers": ["robin@doe.com", "kim@doe.com"],
                 "owners": ["alex@doe.com"],
                 "non-sensitive": False,
-                "token_path": "/foo/bar"
+                "auth_token": "1234"
             }
 
             response = requests.request("POST", url, json=payload)
         """
 
-        required_members = ["token_path"]
+        required_members = ["auth_token"]
         project_metadata = self.body_as_object(required_members=required_members)
 
         dds_project_id = await self.dds_service.create_dds_project(project_name, project_metadata)

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -24,16 +24,16 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
     def post(self, staging_id):
         required_members = ["delivery_project_id"]
         if self.dds:
-            required_members += ["token_path"]
+            required_members += ["auth_token"]
         request_data = self.body_as_object(required_members=required_members)
 
         delivery_project_id = request_data["delivery_project_id"]
-        token_path = request_data.get("token_path")
+        auth_token = request_data.get("auth_token")
         md5sum_file = request_data.get("md5sums_file")
 
         extra_args = {}
-        if token_path:
-            extra_args['token_path'] = token_path
+        if auth_token:
+            extra_args['auth_token'] = auth_token
 
         # This should only be used for testing purposes /JD 20170202
         skip_mover_request = request_data.get("skip_mover")

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -60,7 +60,7 @@ class TestIntegrationDDS(BaseIntegration):
                 delivery_body = {
                         'delivery_project_id': 'fakedeliveryid2016',
                         'dds': True,
-                        'token_path': 'token_path',
+                        'auth_token': '1234',
                         'skip_mover': True,
                         }
                 delivery_resp = yield self.http_client.fetch(self.get_url(delivery_url), method='POST', body=json.dumps(delivery_body))
@@ -102,7 +102,7 @@ class TestIntegrationDDS(BaseIntegration):
                         'delivery_project_id': 'fakedeliveryid2016',
                         'skip_mover': True,
                         'dds': True,
-                        'token_path': 'token_path',
+                        'auth_token': '1234',
                         }
                 delivery_resp = yield self.http_client.fetch(self.get_url(delivery_url), method='POST', body=json.dumps(delivery_body))
                 delivery_resp_as_json = json.loads(delivery_resp.body)
@@ -214,7 +214,7 @@ class TestIntegrationDDS(BaseIntegration):
             "researchers": ["robin@doe.com", "kim@doe.com"],
             "owners": ["alex@doe.com"],
             "non-sensitive": False,
-            "token_path": '/foo/bar/auth',
+            "auth_token": '1234',
         }
 
         response = yield self.http_client.fetch(
@@ -234,7 +234,7 @@ class TestIntegrationDDS(BaseIntegration):
             "researchers": ["robin@doe.com", "kim@doe.com"],
             "owners": ["alex@doe.com"],
             "non-sensitive": False,
-            "token_path": '/foo/bar/auth',
+            "auth_token": '1234',
         }
 
         response = yield self.http_client.fetch(
@@ -294,7 +294,7 @@ class TestIntegrationDDSLongWait(BaseIntegration):
                 delivery_body = {
                         'delivery_project_id': 'fakedeliveryid2016',
                         'dds': True,
-                        'token_path': 'token_path',
+                        'auth_token': '1234',
                         'skip_mover': False,
                         }
                 delivery_response = self.http_client.fetch(self.get_url(delivery_url), method='POST', body=json.dumps(delivery_body))


### PR DESCRIPTION
**What problems does this PR solve?**
DDS imposes strong constraints on who can access the authentication token. For instance, as of now it is not possible to set group permissions on the token.

This PR makes it possible to send the token directly through the API call or to place it in a shared folder on Miarka.

**How has the changes been tested?**
 Unit tests have been adapted and more tests will be performed in staging.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
