### PR TITLE
Respond immediately during delivery

### DIFF
--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -194,7 +194,7 @@ class DDSService(object):
             delivery_order.delivery_status = DeliveryStatus.delivery_skipped
             session.commit()
         else:
-            yield DDSService._run_dds_put(**args_for_run_dds_put)
+            DDSService._run_dds_put(**args_for_run_dds_put)
 
         log.info(f"Removing staged runfolder at {stage_order.staging_target}")
         shutil.rmtree(stage_order.staging_target)

--- a/requirements/prod
+++ b/requirements/prod
@@ -5,4 +5,4 @@ sqlalchemy==1.4.35
 alembic==1.7.7
 enum34==1.1.10
 arteria==1.1.3
-dds-cli==1.0.5
+dds-cli==1.0.6

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -260,38 +260,28 @@ class TestIntegrationDDSShortWait(BaseIntegration):
         self.mock_duration = 2
 
     @gen_test(timeout=2+1)
-    def test_mock_duration_is_10(self):
-        with tempfile.TemporaryDirectory(dir='./tests/resources/runfolders/', prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
+    def test_mock_duration_is_2(self):
+        with tempfile.TemporaryDirectory(
+                dir='./tests/resources/runfolders/',
+                prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
 
             dir_name = os.path.basename(tmp_dir)
             self._create_projects_dir_with_random_data(tmp_dir)
             self._create_checksums_file(tmp_dir)
 
             url = "/".join([self.API_BASE, "stage", "runfolder", dir_name])
-            response = yield self.http_client.fetch(self.get_url(url), method='POST', body='')
-            self.assertEqual(response.code, 202)
+            response = yield self.http_client.fetch(
+                    self.get_url(url),
+                    method='POST',
+                    body='')
 
             response_json = json.loads(response.body)
-
-            staging_status_links = response_json.get("staging_order_links")
-
-            for project, link in staging_status_links.items():
-
-                self.assertEqual(project, "ABC_123")
-
-                status_response = yield self.http_client.fetch(link)
-                self.assertEqual(json.loads(status_response.body)["status"], StagingStatus.staging_successful.name)
-
-
-                # The size of the fake project is 1024 bytes
-                status_response = yield self.http_client.fetch(link)
-                self.assertEqual(json.loads(status_response.body)["size"], 1024)
 
             staging_order_project_and_id = response_json.get("staging_order_ids")
 
             for project, staging_id in staging_order_project_and_id.items():
-                self.assertTrue(os.path.exists(f"/tmp/{staging_id}/{project}"))
-                delivery_url = '/'.join([self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
+                delivery_url = '/'.join([
+                    self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
                         'delivery_project_id': 'fakedeliveryid2016',
                         'dds': True,
@@ -301,7 +291,10 @@ class TestIntegrationDDSShortWait(BaseIntegration):
 
                 start = time.time()
 
-                delivery_resp = yield self.http_client.fetch(self.get_url(delivery_url), method='POST', body=json.dumps(delivery_body))
+                delivery_resp = yield self.http_client.fetch(
+                        self.get_url(delivery_url),
+                        method='POST',
+                        body=json.dumps(delivery_body))
 
                 delivery_resp_as_json = json.loads(delivery_resp.body)
                 delivery_link = delivery_resp_as_json['delivery_order_link']
@@ -316,7 +309,6 @@ class TestIntegrationDDSShortWait(BaseIntegration):
                 stop = time.time()
                 self.assertTrue(stop - start >= self.mock_duration)
 
-                self.assertFalse(os.path.exists(f"/tmp/{staging_id}/{project}"))
 
 class TestIntegrationDDSLongWait(BaseIntegration):
     def __init__(self, *args):
@@ -326,44 +318,36 @@ class TestIntegrationDDSLongWait(BaseIntegration):
 
     @gen_test
     def test_can_deliver_and_not_timeout(self):
-        with tempfile.TemporaryDirectory(dir='./tests/resources/runfolders/', prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
+        with tempfile.TemporaryDirectory(
+                dir='./tests/resources/runfolders/',
+                prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
 
             dir_name = os.path.basename(tmp_dir)
             self._create_projects_dir_with_random_data(tmp_dir)
             self._create_checksums_file(tmp_dir)
 
             url = "/".join([self.API_BASE, "stage", "runfolder", dir_name])
-            response = yield self.http_client.fetch(self.get_url(url), method='POST', body='')
-            self.assertEqual(response.code, 202)
+            response = yield self.http_client.fetch(
+                    self.get_url(url), method='POST', body='')
 
             response_json = json.loads(response.body)
 
-            staging_status_links = response_json.get("staging_order_links")
-
-            for project, link in staging_status_links.items():
-
-                self.assertEqual(project, "ABC_123")
-
-                status_response = yield self.http_client.fetch(link)
-                self.assertEqual(json.loads(status_response.body)["status"], StagingStatus.staging_successful.name)
-
-
-                # The size of the fake project is 1024 bytes
-                status_response = yield self.http_client.fetch(link)
-                self.assertEqual(json.loads(status_response.body)["size"], 1024)
-
-            staging_order_project_and_id = response_json.get("staging_order_ids")
+            staging_order_project_and_id = response_json.get(
+                    "staging_order_ids")
 
             for project, staging_id in staging_order_project_and_id.items():
-                self.assertTrue(os.path.exists(f"/tmp/{staging_id}"))
-                delivery_url = '/'.join([self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
+                delivery_url = '/'.join([
+                    self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
                         'delivery_project_id': 'fakedeliveryid2016',
                         'dds': True,
                         'auth_token': '1234',
                         'skip_mover': False,
                         }
-                delivery_response = yield self.http_client.fetch(self.get_url(delivery_url), method='POST', body=json.dumps(delivery_body))
+                delivery_response = yield self.http_client.fetch(
+                        self.get_url(delivery_url),
+                        method='POST',
+                        body=json.dumps(delivery_body))
 
 
 class TestIntegrationDDSUnmocked(BaseIntegration):

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -318,6 +318,11 @@ class TestIntegrationDDSLongWait(BaseIntegration):
 
     @gen_test
     def test_can_deliver_and_not_timeout(self):
+        """
+        This test checks that the service does not wait for the full duration
+        of the delivery (10s in this case) to respond. If it does wait, it will
+        raise a time-out error after 5s (default duration of tornado tests).
+        """
         with tempfile.TemporaryDirectory(
                 dir='./tests/resources/runfolders/',
                 prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
@@ -348,6 +353,8 @@ class TestIntegrationDDSLongWait(BaseIntegration):
                         self.get_url(delivery_url),
                         method='POST',
                         body=json.dumps(delivery_body))
+                self.assertEqual(delivery_response.code, 202)
+
 
 
 class TestIntegrationDDSUnmocked(BaseIntegration):

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -117,6 +117,15 @@ class TestDDSService(AsyncTestCase):
             '--silent'
             ])
 
+        self.mock_mover_runner.run_and_wait.assert_called_with([
+            'dds',
+            '--token-path', 'token_path',
+            '--log-file', '/foo/bar/log',
+            '--no-prompt',
+            'project', 'status', 'release',
+            '--project', 'snpseq00001',
+            ])
+
     @gen_test
     def test_deliver_by_staging_id_raises_on_non_existent_stage_id(self):
         self.mock_staging_service.get_stage_order_by_id.return_value = None


### PR DESCRIPTION
**What problems does this PR solve?**
There is a timeout cap on miarka that prevents us to deliver data and only respond when the data is completed. Instead, we have to roll back to the way it worked with mover: respond immediately after delivery has started and check status regularly until the delivery is completed.

Fixes DEVELOP-2189

Additional changes:
- upgrade dds to 1.0.6 (provides `--allow-group` feature)
- add tests to make sure the sleep mock is working as intended
- release project on DDS after delivery is completed

**How has the changes been tested?**
Unit tests have been adapted

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
