### PR TITLE
Develop 2189: fix asynchronous delivery

### DIFF
--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -158,6 +158,10 @@ class DDSService(object):
             # Always commit the state change to the database
             session.commit()
 
+        log.info(
+            f"Removing staged runfolder at {delivery_order.delivery_source}")
+        shutil.rmtree(delivery_order.delivery_source)
+
         DDSService._release_project(
                 token_path,
                 dds_conf,
@@ -232,11 +236,12 @@ class DDSService(object):
             session = self.session_factory()
             delivery_order.delivery_status = DeliveryStatus.delivery_skipped
             session.commit()
+            log.info(
+                f"Removing staged runfolder at {stage_order.staging_target}")
+            shutil.rmtree(stage_order.staging_target)
         else:
+            # Asynchronous call, all clean-up needs to be done in _run_dds_put
             DDSService._run_dds_put(**args_for_run_dds_put)
-
-        log.info(f"Removing staged runfolder at {stage_order.staging_target}")
-        shutil.rmtree(stage_order.staging_target)
 
         return delivery_order.id
 

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -98,10 +98,16 @@ class BaseIntegration(AsyncHTTPTestCase):
                         for delivery_prgm in ['dds', 'moverinfo', 'to_outbox']):
                     new_cmd = ['sleep', str(self.mock_duration)]
 
-                    if cmd[0].endswith('dds') and 'project' in cmd:
-                        new_cmd += ['&&', 'echo', f'"{dds_output}"']
-                        new_cmd = " ".join(new_cmd)
-                        shell = True
+                    if cmd[0].endswith('dds'):
+                        if 'project' in cmd:
+                            new_cmd += ['&&', 'echo', f'"{dds_output}"']
+                            new_cmd = " ".join(new_cmd)
+                            shell = True
+                        elif 'put' in cmd:
+                            source_file = cmd[cmd.index("--source") + 1]
+                            new_cmd += ['&&', 'test', '-e', source_file]
+                            new_cmd = " ".join(new_cmd)
+                            shell = True
                 else:
                     new_cmd = cmd
 

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -100,11 +100,15 @@ class TestDDSService(AsyncTestCase):
                     delivery_project='snpseq00001',
                     token_path='token_path',
                     md5sum_file='md5sum_file')
+
+            def _get_delivery_order():
+                return self.delivery_order.delivery_status
+            assert_eventually_equals(
+                    self, 1,
+                    _get_delivery_order, DeliveryStatus.delivery_successful)
+
             mock_rmtree.assert_called_once_with(staging_target)
 
-        def _get_delivery_order():
-            return self.delivery_order.delivery_status
-        assert_eventually_equals(self, 1, _get_delivery_order, DeliveryStatus.delivery_successful)
         self.mock_mover_runner.run.assert_called_with([
             'dds',
             '--token-path', 'token_path',


### PR DESCRIPTION
**What problems does this PR solve?**
The call to DDS is done asynchronously. This means we need to wait for this call to complete before we can clean the staging target. This PR moves the clean-up step inside the asynchronous call to make sure we don't remove the data prematurely.

**How has the changes been tested?**
Automatic tests have been added to make sure staged data is kept for the whole duration of the delivery.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
