### PR TITLE
Develop 2422 send delivery email

### DIFF
--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -34,6 +34,7 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
         auth_token = request_data["auth_token"]
         deadline = request_data.get("deadline")
         release = request_data.get("release", True)
+        email = request_data.get("email", True)
 
         # This should only be used for testing purposes /JD 20170202
         skip_delivery_request = request_data.get("skip_delivery")
@@ -54,6 +55,7 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
                 skip_delivery=skip_delivery,
                 deadline=deadline,
                 release=release,
+                email=email,
                 )
 
         status_end_point = "{0}://{1}{2}".format(

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -264,6 +264,7 @@ class DDSProject:
             skip_delivery=False,
             deadline=None,
             release=True,
+            email=True,
             ):
         """
         Upload staged data to DDS
@@ -323,12 +324,13 @@ class DDSProject:
                     delivery_order,
                     staging_order,
                     deadline=deadline,
-                    release=release)
+                    release=release,
+                    email=email)
 
         return delivery_order.id
 
     @gen.coroutine
-    def release(self, deadline=None):
+    def release(self, deadline=None, email=True):
         """
         Release the project in DDS
 
@@ -342,13 +344,16 @@ class DDSProject:
         cmd += [
                 'project', 'status', 'release',
                 '--project', self.project_id,
-                '--no-mail',
                 ]
 
         if deadline:
             cmd += [
                 '--deadline', str(deadline),
                 ]
+
+        if not email:
+            cmd.append('--no-mail')
+
         yield self._run(cmd)
 
     @gen.coroutine
@@ -383,6 +388,7 @@ class DDSProject:
             staging_order,
             deadline=None,
             release=True,
+            email=True,
             ):
         """
         Start a delivery and release the project in DDS
@@ -424,7 +430,7 @@ class DDSProject:
                     # specific endpoint, e.g. if we want to do several
                     # deliveries before releasing a project /AC 2022-06-23
                     log.info(f"Releasing project {self.project_id}")
-                    yield self.release(deadline=deadline)
+                    yield self.release(deadline=deadline, email=email)
 
                 delivery_order.delivery_status = DeliveryStatus.delivery_successful
                 log.info(f"Successfully delivered: {delivery_order}")

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -278,7 +278,7 @@ class TestIntegrationDDSShortWait(BaseIntegration):
                         'ngi_project_name': 'AB-1234',
                         'dds': True,
                         'auth_token': '1234',
-                        'skip_mover': False,
+                        'skip_delivery': False,
                         }
 
                 start = time.time()
@@ -329,7 +329,7 @@ class TestIntegrationDDSShortWait(BaseIntegration):
                         'ngi_project_name': 'AB-1234',
                         'dds': True,
                         'auth_token': '1234',
-                        'skip_mover': False,
+                        'skip_delivery': False,
                         }
 
                 delivery_resp = yield self.http_client.fetch(

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -131,7 +131,6 @@ class TestDDSService(AsyncTestCase):
                         '--no-prompt',
                         'project', 'status', 'release',
                         '--project', project_id,
-                        '--no-mail',
                         '--deadline', deadline,
                         ]),
                     ])
@@ -340,12 +339,16 @@ project"""
     def test_release_project(self):
         project_id = 'snpseq00001'
         deadline = '90'
+        email = True
         dds_project = DDSProject(
                 dds_service=self.dds_service,
                 auth_token=self.token_file.name,
                 dds_project_id=project_id)
 
-        yield dds_project.release(deadline=deadline)
+        yield dds_project.release(
+                deadline=deadline,
+                email=email,
+                )
 
         self.mock_dds_runner.run.assert_called_with([
             'dds',
@@ -354,8 +357,33 @@ project"""
             '--no-prompt',
             'project', 'status', 'release',
             '--project', project_id,
-            '--no-mail',
             '--deadline', deadline,
+            ])
+
+    @gen_test
+    def test_release_project_nomail(self):
+        project_id = 'snpseq00001'
+        deadline = '90'
+        email = False
+        dds_project = DDSProject(
+                dds_service=self.dds_service,
+                auth_token=self.token_file.name,
+                dds_project_id=project_id)
+
+        yield dds_project.release(
+                deadline=deadline,
+                email=email,
+                )
+
+        self.mock_dds_runner.run.assert_called_with([
+            'dds',
+            '--token-path', self.token_file.name,
+            '--log-file', '/foo/bar/log',
+            '--no-prompt',
+            'project', 'status', 'release',
+            '--project', project_id,
+            '--deadline', deadline,
+            '--no-mail',
             ])
 
     @gen_test


### PR DESCRIPTION
**What problems does this PR solve?**
Project coordinators want DDS to send an email to the user when data is available. This PR makes this the default behavior (but also makes it possible to disable it if needed).

**How has the changes been tested?**
Unit-tests have been updated.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
