### PR TITLE
Implement stage-free delivery for project deliveries.

### DIFF
--- a/alembic/versions/69ebc95e3ecb_add_ddsdelivery_and_ddsput_models.py
+++ b/alembic/versions/69ebc95e3ecb_add_ddsdelivery_and_ddsput_models.py
@@ -1,0 +1,61 @@
+"""Add DDSDelivery and DDSPut Models
+
+Revision ID: 69ebc95e3ecb
+Revises: 74b309c44134
+Create Date: 2023-03-10 16:10:37.844346
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '69ebc95e3ecb'
+down_revision = '74b309c44134'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'dds_deliveries',
+        sa.Column('dds_project_id', sa.String, primary_key=True),
+        sa.Column('ngi_project_name', sa.String),
+        sa.Column('date_started', sa.DateTime, nullable=False),
+        sa.Column('date_completed', sa.DateTime),
+        sa.Column('delivery_status', sa.Enum(
+            'pending',
+            'delivery_in_progress',
+            'delivery_successful',
+            'delivery_failed',
+            'delivery_skipped',
+            name='deliverystatus'
+        )),
+    )
+
+    op.create_table(
+        'dds_puts',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            'dds_project_id',
+            sa.String,
+            sa.ForeignKey("dds_deliveries.dds_project_id"),
+            nullable=False),
+        sa.Column('dds_pid', sa.Integer, nullable=False),
+        sa.Column('delivery_source', sa.String, nullable=False),
+        sa.Column('delivery_path', sa.String, nullable=False),
+        sa.Column('destination', sa.String),
+        sa.Column('date_started', sa.DateTime, nullable=False),
+        sa.Column('date_completed', sa.DateTime),
+        sa.Column('delivery_status', sa.Enum(
+            'pending',
+            'delivery_in_progress',
+            'delivery_successful',
+            'delivery_failed',
+            'delivery_skipped',
+            name='deliverystatus'
+        )),
+    )
+
+def downgrade():
+    op.drop_table('dds_puts')
+    op.drop_table('dds_deliveries')

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -25,6 +25,8 @@ from delivery.repositories.runfolder_repository import FileSystemBasedRunfolderR
     FileSystemBasedUnorganisedRunfolderRepository
 from delivery.repositories.staging_repository import DatabaseBasedStagingRepository
 from delivery.repositories.deliveries_repository import DatabaseBasedDeliveriesRepository
+from delivery.repositories.dds_repository import DatabaseBasedDDSDeliveryRepository, \
+    DatabaseBasedDDSPutRepository
 from delivery.repositories.project_repository import GeneralProjectRepository, UnorganisedRunfolderProjectRepository
 from delivery.repositories.delivery_sources_repository import DatabaseBasedDeliverySourcesRepository
 from delivery.repositories.sample_repository import RunfolderProjectBasedSampleRepository
@@ -159,6 +161,10 @@ def compose_application(config):
 
     delivery_repo = DatabaseBasedDeliveriesRepository(
             session_factory=session_factory)
+    dds_delivery_repo = DatabaseBasedDDSDeliveryRepository(
+            session_factory=session_factory)
+    dds_put_repo = DatabaseBasedDDSPutRepository(
+            session_factory=session_factory)
 
     dds_conf = config['dds_conf']
     dds_service = DDSService(
@@ -166,6 +172,8 @@ def compose_application(config):
             staging_service=staging_service,
             staging_dir=staging_dir,
             delivery_repo=delivery_repo,
+            dds_delivery_repo=dds_delivery_repo,
+            dds_put_repo=dds_put_repo,
             session_factory=session_factory,
             dds_conf=dds_conf)
 

--- a/delivery/app.py
+++ b/delivery/app.py
@@ -16,7 +16,8 @@ from delivery.handlers.runfolder_handlers import RunfolderHandler
 from delivery.handlers.project_handlers import ProjectHandler, ProjectsForRunfolderHandler, \
     BestPracticeProjectSampleHandler
 from delivery.handlers.dds_handlers import DDSCreateProjectHandler
-from delivery.handlers.delivery_handlers import DeliverByStageIdHandler, DeliveryStatusHandler
+from delivery.handlers.delivery_handlers import DeliverByStageIdHandler, \
+    DeliveryStatusHandler, DeliverProjectHandler
 from delivery.handlers.staging_handlers import StagingRunfolderHandler, StagingHandler,\
     StageGeneralDirectoryHandler, StagingProjectRunfoldersHandler
 from delivery.handlers.organise_handlers import OrganiseRunfolderHandler
@@ -76,6 +77,8 @@ def routes(**kwargs):
 
         url(r"/api/1.0/deliver/status/(.+)", DeliveryStatusHandler,
             name="delivery_status", kwargs=kwargs),
+        url(r"/api/1.0/deliver/project/(.+)", DeliverProjectHandler,
+            name="deliver_project", kwargs=kwargs),
 
         url(r"/api/1.0/dds_project/create/(.+)", DDSCreateProjectHandler,
             name="create_dds_project", kwargs=kwargs),

--- a/delivery/handlers/dds_handlers.py
+++ b/delivery/handlers/dds_handlers.py
@@ -46,7 +46,11 @@ class DDSCreateProjectHandler(DDSProjectBaseHandler):
             response = requests.request("POST", url, json=payload)
         """
 
-        required_members = ["auth_token"]
+        required_members = [
+                "auth_token",
+                "pi",
+                "description",
+                ]
         project_metadata = self.body_as_object(
                 required_members=required_members)
 

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -50,7 +50,7 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
                 auth_token,
                 delivery_project_id)
 
-        delivery_id = yield dds_project.put(
+        delivery_id = yield dds_project.deliver(
                 staging_id,
                 skip_delivery=skip_delivery,
                 deadline=deadline,

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -12,6 +12,92 @@ from delivery.models.project import DDSProject
 
 log = logging.getLogger(__name__)
 
+
+class DeliverProjectHandler(ArteriaDeliveryBaseHandler):
+    """
+    Handler for delivering a project a project (i.e. a directory placed in the
+    directory defined by the arteria delivery service
+    `general_project_directory` configuration).
+    """
+    def initialize(self, **kwargs):
+        self.dds_service = kwargs["dds_service"]
+        self.general_project_repo = kwargs["general_project_repo"]
+        super().initialize(kwargs)
+
+    async def post(self, project_name):
+        required_members = [
+            "auth_token",
+            "pi",
+            "description",
+        ]
+
+        request_data = self.body_as_object(
+            required_members=required_members)
+
+        project_metadata = {
+            key: request_data[key]
+            for key in [
+                "pi",
+                "description",
+                "owners",
+                "researchers",
+                "project_alias",
+            ]
+            if key in request_data
+        }
+
+        force_delivery = request_data.get("force_delivery", False)
+
+        if (
+                self.dds_service.dds_put_repo
+                .was_delivered_before(project_name, project_name)
+                and not force_delivery
+        ):
+            self.set_status(
+                FORBIDDEN,
+                f"The project {project_name} has already been delivered. "
+                "Use the force to bypass and deliver anyway."
+            )
+            return
+
+        project_path = self.general_project_repo.get_project(
+            project_metadata.get("project_alias", project_name)).path
+
+        dds_project = await DDSProject.new(
+            project_name,
+            project_metadata,
+            request_data["auth_token"],
+            self.dds_service)
+
+        log.info(
+            f"New dds project created for project {project_name} "
+            f"with id {dds_project.project_id}"
+        )
+
+        self.set_status(ACCEPTED)
+        self.write_json({
+            'dds_project_id': dds_project.project_id,
+            'status_link': "{0}://{1}{2}".format(
+                self.request.protocol,
+                self.request.host,
+                self.reverse_url("delivery_status", dds_project.project_id)
+            )
+        })
+        self.finish()
+
+        await dds_project.put(project_name, project_path)
+        log.info(f"Uploaded {project_path} to {dds_project.project_id}")
+
+        if request_data.get("release"):
+            await dds_project.release(
+                deadline=request_data.get("deadline", None),
+                email=request_data.get("email", True),
+            )
+            log.info(f"Released project {dds_project.project_id}")
+
+        dds_project.complete()
+
+
 class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
     """
     Handler for starting deliveries based on a previously staged directory/file

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -26,6 +26,39 @@ class DeliverProjectHandler(ArteriaDeliveryBaseHandler):
         super().initialize(kwargs)
 
     async def post(self, project_name):
+        """
+        Deliver a project (represented by a directory under the
+        `general_project_directory` path defined in the configuration). This
+        will create a new project in DDS, upload the data and release the
+        project.
+
+        The payload can include the following fields:
+        auth_token: str (required)
+            token to authenticate in DDS, can be either the token string itself
+            or a path to the token file.
+        pi: str (required)
+            email address the the principal investigator of the project
+        description: str (required)
+            description of the project
+        owners: [str]
+            email addresses of the people who are to be set as owners of the
+            project.
+        researchers: [str]
+            email addresses of the people who are to be set as researchers in
+            the project.
+        project_alias: str
+            name of the directory containing the project in case it is
+            different from the project name
+        force_delivery: bool
+            enforce delivery, regardless if the data has been delivered before
+            or not.
+        deadline: int
+            number of days when the user will be able to download the data
+            (otherwise the value defined in the DDS aggreement will be used).
+        email: bool
+            whether or not an email should be sent to the user when the project
+            is *released* (default is true).
+        """
         required_members = [
             "auth_token",
             "pi",

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -164,6 +164,7 @@ class DDSDelivery(SQLAlchemyBase):
             " }"
         )
 
+
 class DDSPut(SQLAlchemyBase):
 
     __tablename__ = "dds_puts"

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -1,6 +1,8 @@
 
 import os
+import datetime
 import enum as base_enum
+import psutil
 
 from sqlalchemy import Column, ForeignKey
 from sqlalchemy import Integer, BigInteger, String, Enum, DateTime
@@ -195,3 +197,18 @@ class DDSPut(SQLAlchemyBase):
             f"delivery_status: {self.delivery_status}, "
             " }"
         )
+
+    def is_running(self):
+        try:
+            process = psutil.Process(self.dds_pid)
+            date_created = datetime.datetime.fromtimestamp(
+                process.create_time())
+            return (
+                process.name() == 'dds'
+                and (
+                    abs(date_created - self.date_started)
+                    < datetime.timedelta(minutes=1)
+                )
+            )
+        except psutil.NoSuchProcess:
+            return False

--- a/delivery/models/db_models.py
+++ b/delivery/models/db_models.py
@@ -2,7 +2,8 @@
 import os
 import enum as base_enum
 
-from sqlalchemy import Column, Integer, BigInteger, String, Enum
+from sqlalchemy import Column, ForeignKey
+from sqlalchemy import Integer, BigInteger, String, Enum, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 
 """
@@ -138,3 +139,59 @@ class DeliveryOrder(SQLAlchemyBase):
                 f"status: {self.delivery_status}, "
                 " }"
                 )
+
+class DDSDelivery(SQLAlchemyBase):
+
+    __tablename__ = "dds_deliveries"
+
+    dds_project_id = Column(String, primary_key=True)
+    ngi_project_name = Column(String)
+
+    date_started = Column(DateTime, nullable=False)
+    date_completed = Column(DateTime)
+    delivery_status = Column(Enum(DeliveryStatus), nullable=False)
+
+    def __repr__(self):
+        return (
+            "DDS Delivery: {"
+            f"dds_project: '{self.dds_project}', "
+            f"ngi_project_name: '{self.ngi_project_name}', "
+            f"date_started: {self.date_started}, "
+            f"date_completed: {self.date_completed}, "
+            f"delivery_status: {self.delivery_status}, "
+            " }"
+        )
+
+class DDSPut(SQLAlchemyBase):
+
+    __tablename__ = "dds_puts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    dds_project_id = Column(
+        String,
+        ForeignKey("dds_deliveries.dds_project_id"),
+        nullable=False)
+    dds_pid = Column(Integer, nullable=False)
+
+    delivery_source = Column(String, nullable=False)
+    delivery_path = Column(String, nullable=False)
+    destination = Column(String)
+
+    date_started = Column(DateTime, nullable=False)
+    date_completed = Column(DateTime)
+    delivery_status = Column(Enum(DeliveryStatus), nullable=False)
+
+    def __repr__(self):
+        return (
+            "DDS Put: {"
+            f"id: {self.id},"
+            f"dds_project: '{self.dds_project}', "
+            f"dds_pid: {self.dds_pid}, "
+            f"delivery_source: '{self.delivery_source}', "
+            f"delivery_path: '{self.delivery_path}', "
+            f"destination: '{self.destination}', "
+            f"date_started: {self.date_started}, "
+            f"date_completed: {self.date_completed}, "
+            f"delivery_status: {self.delivery_status}, "
+            " }"
+        )

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -211,9 +211,11 @@ class DDSProject:
             for args in ['--researcher', researcher]
             ]
 
-        stdout = yield self.dds_service.external_program_service \
-            .run_and_wait(cmd).stdout
-        self.project_id = cls._parse_dds_project_id(stdout)
+        execution = self.dds_service.external_program_service \
+            .run(cmd)
+        result = yield self.dds_service.external_program_service \
+            .wait_for_execution(execution)
+        self.project_id = cls._parse_dds_project_id(result.stdout)
 
         self.dds_service.dds_delivery_repo.register_dds_delivery(
             self.project_id,
@@ -371,7 +373,9 @@ class DDSProject:
         if not email:
             cmd.append('--no-mail')
 
-        yield self.dds_service.external_program_service.run_and_wait(cmd)
+        execution = self.dds_service.external_program_service.run(cmd)
+        yield self.dds_service.external_program_service. \
+            wait_for_execution(execution)
 
     @gen.coroutine
     def _run_delivery(

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -254,7 +254,7 @@ class DDSProject:
         return self._ngi_project_name
 
     @gen.coroutine
-    def put(
+    def deliver(
             self,
             staging_id,
             skip_delivery=False,
@@ -263,7 +263,7 @@ class DDSProject:
             email=True,
             ):
         """
-        Upload staged data to DDS
+        Deliver staged data to DDS
 
         Parameters
         ----------

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -277,6 +277,36 @@ class DDSProject:
             self.dds_service.dds_put_repo.session.commit()
 
     @gen.coroutine
+    def release(self, deadline=None, email=True):
+        """
+        Release the project in DDS
+
+        Parameters
+        ----------
+        deadline: int
+            project deadline in days.
+        """
+        cmd = self._base_cmd[:]
+
+        cmd += [
+            'project', 'status', 'release',
+            '--project', self.project_id,
+        ]
+
+        if deadline:
+            cmd += [
+                '--deadline', str(deadline),
+                ]
+
+        if not email:
+            cmd.append('--no-mail')
+
+        execution = self.dds_service.external_program_service.run(cmd)
+        yield self.dds_service.external_program_service. \
+            wait_for_execution(execution)
+
+# The code below will be removed once the new delivery flow is in place
+    @gen.coroutine
     def deliver(
             self,
             staging_id,
@@ -347,35 +377,6 @@ class DDSProject:
                     email=email)
 
         return delivery_order.id
-
-    @gen.coroutine
-    def release(self, deadline=None, email=True):
-        """
-        Release the project in DDS
-
-        Parameters
-        ----------
-        deadline: int
-            project deadline in days.
-        """
-        cmd = self._base_cmd[:]
-
-        cmd += [
-                'project', 'status', 'release',
-                '--project', self.project_id,
-                ]
-
-        if deadline:
-            cmd += [
-                '--deadline', str(deadline),
-                ]
-
-        if not email:
-            cmd.append('--no-mail')
-
-        execution = self.dds_service.external_program_service.run(cmd)
-        yield self.dds_service.external_program_service. \
-            wait_for_execution(execution)
 
     @gen.coroutine
     def _run_delivery(

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -214,6 +214,11 @@ class DDSProject:
         stdout = yield self._run(cmd)
         self.project_id = cls._parse_dds_project_id(stdout)
 
+        self.dds_service.dds_delivery_repo.register_dds_delivery(
+            self.project_id,
+            ngi_project_name,
+        )
+
         self._ngi_project_name = ngi_project_name
 
         return self

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -331,6 +331,18 @@ class DDSProject:
         yield self.dds_service.external_program_service. \
             wait_for_execution(execution)
 
+    def complete(self):
+        """
+        Set project status to completed in the database
+        """
+        assert not self.has_ongoing_puts(), \
+            "Cannot complete project while uploads are ongoing"
+
+        dds_delivery = self.dds_service.dds_delivery_repo \
+            .get_dds_delivery(self.project_id)
+        dds_delivery.delivery_status = DeliveryStatus.delivery_successful
+        self.dds_service.dds_delivery_repo.session.commit()
+
 # The code below will be removed once the new delivery flow is in place
     @gen.coroutine
     def deliver(

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -211,7 +211,8 @@ class DDSProject:
             for args in ['--researcher', researcher]
             ]
 
-        stdout = yield self._run(cmd)
+        stdout = yield self.dds_service.external_program_service \
+            .run_and_wait(cmd).stdout
         self.project_id = cls._parse_dds_project_id(stdout)
 
         self.dds_service.dds_delivery_repo.register_dds_delivery(
@@ -329,31 +330,7 @@ class DDSProject:
         if not email:
             cmd.append('--no-mail')
 
-        yield self._run(cmd)
-
-    @gen.coroutine
-    def _run(self, cmd):
-        """
-        Run a dds command and wait for result.
-
-        Parameters
-        ----------
-        cmd: str
-            shell command to run.
-        """
-        log.debug(f"Running dds with command: {' '.join(cmd)}")
-        execution = self.dds_service.external_program_service.run(cmd)
-        execution_result = yield self.dds_service.external_program_service \
-            .wait_for_execution(execution)
-
-        if execution_result.status_code != 0:
-            error_msg = (
-                f"Failed to run DDS command: {execution_result.stderr}."
-                f" DDS returned status code: {execution_result.status_code}")
-            log.error(error_msg)
-            raise RuntimeError(error_msg)
-
-        return execution_result.stdout
+        yield self.dds_service.external_program_service.run_and_wait(cmd)
 
     @gen.coroutine
     def _run_delivery(

--- a/delivery/repositories/dds_repository.py
+++ b/delivery/repositories/dds_repository.py
@@ -19,6 +19,17 @@ class DatabaseBasedDDSRepository:
         raise NotImplementedError
 
     def set_to_completed(self, primary_key, date_completed=None):
+        """
+        Set status to `delivery_successful` and set date of completion.
+
+        Parameters
+        ----------
+        primary_key: str
+            id to row in database
+        date_completed: datetime
+            date of completion, if None, the current time and date will be
+            used.
+        """
         if not date_completed:
             date_completed = datetime.datetime.now()
 
@@ -30,6 +41,16 @@ class DatabaseBasedDDSRepository:
         self.session.commit()
 
     def update_status(self, primary_key, new_status):
+        """
+        Update status of the given delivery
+
+        Parameters
+        ----------
+        primary_key: str
+            id to row in database
+        new_status: DeliveryStatus
+            new delivery status
+        """
         row = self._get_row(primary_key)
         row.delivery_status = new_status
         self.session.commit()
@@ -49,6 +70,26 @@ class DatabaseBasedDDSDeliveryRepository(DatabaseBasedDDSRepository):
             date_started=None,
             delivery_status=None,
     ):
+        """
+        Add a new delivery to the database. By default, starting date will be
+        set to the current date and delivery status will be set to
+        `delivery_in_progress`.
+
+        Parameters
+        ----------
+        dds_project_id: str (e.g. snpseq00000)
+            project id provided by dds, must be unique
+        ngi_project_name: str (e.g. AB-1234)
+            name of the project (typically project name in Clarity)
+        date_started: datetime
+            date when the delivery was started
+        delivery_status: DeliveryStatus
+            Initial delivery status
+
+        Returns
+        -------
+        DDSDelivery
+        """
         if not date_started:
             date_started = datetime.datetime.now()
 
@@ -68,6 +109,18 @@ class DatabaseBasedDDSDeliveryRepository(DatabaseBasedDDSRepository):
         return dds_delivery
 
     def get_dds_delivery(self, dds_project_id):
+        """
+        Get a delivery by dds project id from the database
+
+        Parameters
+        ----------
+        dds_project_id: str (e.g. snpseq00000)
+            id of the project
+
+        Returns
+        -------
+        DDSDelivery
+        """
         return self._get_row(dds_project_id)
 
 
@@ -85,6 +138,35 @@ class DatabaseBasedDDSPutRepository(DatabaseBasedDDSRepository):
             date_started=None,
             delivery_status=None,
     ):
+        """
+        Register a new upload in the database. By default, starting date will
+        be set to the current date and delivery status will be set to
+        `delivery_in_progress`.
+
+        Parameters
+        ----------
+        dds_project_id: str (e.g. snpseq00000)
+            id of the project the data is uploaded to
+        dds_pid: int
+            id of the dds process uploading the data
+        delivery_source: str
+            unique identifier to the folder being uploaded (e.g. project name
+            or runfolder name). This is used to avoid delivering the same item
+            twice.
+        delivery_path: str
+            path to the data being uploaded
+        destination: str
+            path where to upload the data in the dds project
+        date_started: datetime
+            date when the upload was started (by default, will use the current
+            time)
+        delivery_status: DeliveryStatus
+            Initial status of the upload
+
+        Returns
+        -------
+        DDSPut
+        """
         if not date_started:
             date_started = datetime.datetime.now()
 
@@ -106,10 +188,39 @@ class DatabaseBasedDDSPutRepository(DatabaseBasedDDSRepository):
 
         return dds_put
 
-    def get_dds_put(self, row_id):
-        return self._get_row(row_id)
+    def get_dds_put(self, primary_key):
+        """
+        Return a dds put entry from the database
+
+        Parameters
+        ----------
+        primary_key: int
+            id of the entry
+
+        Returns
+        -------
+        DDSPut
+        """
+        return self._get_row(primary_key)
 
     def was_delivered_before(self, ngi_project_name, source):
+        """
+        Returns if a source belonging to a specific project has been delivered
+        before.
+
+        Parameters
+        ----------
+        ngi_project_name: str (e.g. AB-1234)
+            project name
+        source: str
+            unique identifier to the folder being uploaded (e.g. project name
+            or runfolder name). This is used to avoid delivering the same item
+            twice.
+
+        Returns
+        -------
+        bool
+        """
         return self.session.query(DDSPut) \
             .join(DDSDelivery) \
             .filter(DDSDelivery.ngi_project_name == ngi_project_name) \
@@ -117,6 +228,20 @@ class DatabaseBasedDDSPutRepository(DatabaseBasedDDSRepository):
             .first() is not None
 
     def get_dds_put_by_status(self, dds_project_id, delivery_status):
+        """
+        Returns all uploads to a specific project with the given status
+
+        Parameters
+        ----------
+        dds_project_id: str (e.g. snpseq00000)
+            dds project where the uploads were made
+        delivery_status: DeliveryStatus
+            status to filter by
+
+        Returns
+        -------
+        [DDSPut]
+        """
         return self.session.query(DDSPut) \
             .join(DDSDelivery) \
             .filter(DDSDelivery.dds_project_id == dds_project_id) \

--- a/delivery/repositories/dds_repository.py
+++ b/delivery/repositories/dds_repository.py
@@ -4,6 +4,9 @@ from delivery.models.db_models import DDSDelivery, DDSPut, DeliveryStatus
 
 
 class DatabaseBasedDDSRepository:
+    """
+    Base class for DDSDelivery and DDSPut
+    """
     def __init__(self, session_factory):
         """
         Instantiate a new DatabaseBasedDDSRepository
@@ -105,3 +108,17 @@ class DatabaseBasedDDSPutRepository(DatabaseBasedDDSRepository):
 
     def get_dds_put(self, row_id):
         return self._get_row(row_id)
+
+    def was_delivered_before(self, ngi_project_name, source):
+        return self.session.query(DDSPut) \
+            .join(DDSDelivery) \
+            .filter(DDSDelivery.ngi_project_name == ngi_project_name) \
+            .filter(DDSPut.delivery_source == source) \
+            .first() is not None
+
+    def get_dds_put_by_status(self, dds_project_id, delivery_status):
+        return self.session.query(DDSPut) \
+            .join(DDSDelivery) \
+            .filter(DDSDelivery.dds_project_id == dds_project_id) \
+            .filter(DDSPut.delivery_status == delivery_status) \
+            .all()

--- a/delivery/repositories/dds_repository.py
+++ b/delivery/repositories/dds_repository.py
@@ -1,0 +1,107 @@
+import datetime
+
+from delivery.models.db_models import DDSDelivery, DDSPut, DeliveryStatus
+
+
+class DatabaseBasedDDSRepository:
+    def __init__(self, session_factory):
+        """
+        Instantiate a new DatabaseBasedDDSRepository
+        :param session_factory: a factory method that can create a new
+        sqlalchemy Session object.
+        """
+        self.session = session_factory()
+
+    def _get_row(self, primary_key):
+        raise NotImplementedError
+
+    def set_to_completed(self, primary_key, date_completed=None):
+        if not date_completed:
+            date_completed = datetime.datetime.now()
+
+        row = self._get_row(primary_key)
+
+        row.delivery_status = DeliveryStatus.delivery_successful
+        row.date_completed = date_completed
+
+        self.session.commit()
+
+    def update_status(self, primary_key, new_status):
+        row = self._get_row(primary_key)
+        row.delivery_status = new_status
+        self.session.commit()
+
+
+class DatabaseBasedDDSDeliveryRepository(DatabaseBasedDDSRepository):
+    """
+    Class to manipulate the DDSDelivery database.
+    """
+    def _get_row(self, primary_key):
+        return self.session.get(DDSDelivery, primary_key)
+
+    def register_dds_delivery(
+            self,
+            dds_project_id,
+            ngi_project_name,
+            date_started=None,
+            delivery_status=None,
+    ):
+        if not date_started:
+            date_started = datetime.datetime.now()
+
+        if not delivery_status:
+            delivery_status = DeliveryStatus.delivery_in_progress
+
+        dds_delivery = DDSDelivery(
+            dds_project_id=dds_project_id,
+            ngi_project_name=ngi_project_name,
+            date_started=date_started,
+            delivery_status=delivery_status,
+            )
+
+        self.session.add(dds_delivery)
+        self.session.commit()
+
+        return dds_delivery
+
+    def get_dds_delivery(self, dds_project_id):
+        return self._get_row(dds_project_id)
+
+
+class DatabaseBasedDDSPutRepository(DatabaseBasedDDSRepository):
+    def _get_row(self, primary_key):
+        return self.session.get(DDSPut, primary_key)
+
+    def register_dds_put(
+            self,
+            dds_project_id,
+            dds_pid,
+            delivery_source,
+            delivery_path,
+            destination=None,
+            date_started=None,
+            delivery_status=None,
+    ):
+        if not date_started:
+            date_started = datetime.datetime.now()
+
+        if not delivery_status:
+            delivery_status = DeliveryStatus.delivery_in_progress
+
+        dds_put = DDSPut(
+            dds_project_id=dds_project_id,
+            dds_pid=dds_pid,
+            delivery_source=delivery_source,
+            delivery_path=delivery_path,
+            destination=destination,
+            date_started=date_started,
+            delivery_status=delivery_status,
+            )
+
+        self.session.add(dds_put)
+        self.session.commit()
+
+        return dds_put
+
+    def get_dds_put(self, row_id):
+        return self._get_row(row_id)

--- a/delivery/services/dds_service.py
+++ b/delivery/services/dds_service.py
@@ -12,13 +12,20 @@ class DDSService(object):
             staging_service,
             staging_dir,
             delivery_repo,
+            dds_delivery_repo,
+            dds_put_repo,
             session_factory,
             dds_conf):
         self.external_program_service = external_program_service
         self.dds_external_program_service = self.external_program_service
         self.staging_service = staging_service
         self.staging_dir = staging_dir
+        # `delivery_repo` and `dds_delivery_repo` have similar names here but
+        # `delivery_repo` will be removed once we decommission the old API
+        # version /AC 2023-03-09
         self.delivery_repo = delivery_repo
+        self.dds_delivery_repo = dds_delivery_repo
+        self.dds_put_repo = dds_put_repo
         self.session_factory = session_factory
         self.dds_conf = dds_conf
 

--- a/delivery/services/external_program_service.py
+++ b/delivery/services/external_program_service.py
@@ -49,13 +49,3 @@ class ExternalProgramService(object):
             raise RuntimeError(error_msg)
 
         return ExecutionResult(out, err, status_code)
-
-    @staticmethod
-    def run_and_wait(cmd):
-        """
-        Run an external command and wait for it to finish
-        :param cmd: the command to run as a list, i.e. ['ls','-l', '/']
-        :return: an ExecutionResult for the execution
-        """
-        execution = ExternalProgramService.run(cmd)
-        return ExternalProgramService.wait_for_execution(execution)

--- a/requirements/prod
+++ b/requirements/prod
@@ -5,4 +5,5 @@ sqlalchemy==1.4.35
 alembic==1.7.7
 enum34==1.1.10
 arteria==1.1.4
+psutil==5.9.4
 dds-cli

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -93,9 +93,8 @@ class BaseIntegration(AsyncHTTPTestCase):
                 log.debug(f"Mock is called with {cmd}")
                 shell = False
                 if cmd[0].endswith('dds'):
-                    new_cmd = ['sleep', str(self.mock_duration)]
-
                     if 'project' in cmd:
+                        new_cmd = ['sleep', str(0.01)]
                         dds_output = f"""Current user: bio
         Project created with id: {project_id}
         User forskare was associated with Project {project_id} as Owner=True. An e-mail notification has not been sent.
@@ -119,6 +118,7 @@ class BaseIntegration(AsyncHTTPTestCase):
                         new_cmd = " ".join(new_cmd)
                         shell = True
                     elif 'put' in cmd:
+                        new_cmd = ['sleep', str(self.mock_duration)]
                         source_file = cmd[cmd.index("--source") + 1]
                         auth_token = cmd[cmd.index("--token-path") + 1]
                         new_cmd += ['&&', 'test', '-e', source_file]

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -23,6 +23,23 @@ class TestIntegrationDDS(BaseIntegration):
             self._create_projects_dir_with_random_data(tmp_dir)
             self._create_checksums_file(tmp_dir)
 
+            project_name = "AB-1234"
+            url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+            payload = {
+                "description": "Dummy project",
+                "pi": "alex@doe.com",
+                "researchers": ["robin@doe.com", "kim@doe.com"],
+                "owners": ["alex@doe.com"],
+                "auth_token": '1234',
+            }
+
+            response = yield self.http_client.fetch(
+                    self.get_url(url), method='POST',
+                    body=json.dumps(payload))
+
+            self.assertEqual(response.code, 202)
+            dds_project_id = json.loads(response.body)["dds_project_id"]
+
             url = "/".join([self.API_BASE, "stage", "runfolder", dir_name])
             response = yield self.http_client.fetch(self.get_url(url), method='POST', body='')
             self.assertEqual(response.code, 202)
@@ -48,8 +65,8 @@ class TestIntegrationDDS(BaseIntegration):
                 self.assertTrue(os.path.exists(f"/tmp/{staging_id}/{project}"))
                 delivery_url = '/'.join([self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
-                        'delivery_project_id': 'snpseq00025',
-                        'ngi_project_name': 'AB-1234',
+                        'delivery_project_id': dds_project_id,
+                        'ngi_project_name': project_name,
                         'auth_token': '1234',
                         'skip_delivery': True,
                         }
@@ -69,6 +86,22 @@ class TestIntegrationDDS(BaseIntegration):
         # expected to be installed on the system where this runs)
 
         with tempfile.TemporaryDirectory(dir='./tests/resources/projects') as tmp_dir:
+            project_name = "AB-1234"
+            url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+            payload = {
+                "description": "Dummy project",
+                "pi": "alex@doe.com",
+                "researchers": ["robin@doe.com", "kim@doe.com"],
+                "owners": ["alex@doe.com"],
+                "auth_token": '1234',
+            }
+
+            response = yield self.http_client.fetch(
+                    self.get_url(url), method='POST',
+                    body=json.dumps(payload))
+
+            self.assertEqual(response.code, 202)
+            dds_project_id = json.loads(response.body)["dds_project_id"]
 
             dir_name = os.path.basename(tmp_dir)
             url = "/".join([self.API_BASE, "stage", "project", dir_name])
@@ -90,8 +123,8 @@ class TestIntegrationDDS(BaseIntegration):
             for project, staging_id in staging_order_project_and_id.items():
                 delivery_url = '/'.join([self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
-                        'delivery_project_id': 'snpseq00025',
-                        'ngi_project_name': 'AB-1234',
+                        'delivery_project_id': dds_project_id,
+                        'ngi_project_name': project_name,
                         'skip_delivery': True,
                         'dds': True,
                         'auth_token': '1234',
@@ -258,6 +291,23 @@ class TestIntegrationDDSShortWait(BaseIntegration):
             self._create_projects_dir_with_random_data(tmp_dir)
             self._create_checksums_file(tmp_dir)
 
+            project_name = "AB-1234"
+            url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+            payload = {
+                "description": "Dummy project",
+                "pi": "alex@doe.com",
+                "researchers": ["robin@doe.com", "kim@doe.com"],
+                "owners": ["alex@doe.com"],
+                "auth_token": '1234',
+            }
+
+            response = yield self.http_client.fetch(
+                    self.get_url(url), method='POST',
+                    body=json.dumps(payload))
+
+            self.assertEqual(response.code, 202)
+            dds_project_id = json.loads(response.body)["dds_project_id"]
+
             url = "/".join([self.API_BASE, "stage", "runfolder", dir_name])
             response = yield self.http_client.fetch(
                     self.get_url(url),
@@ -272,8 +322,8 @@ class TestIntegrationDDSShortWait(BaseIntegration):
                 delivery_url = '/'.join([
                     self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
-                        'delivery_project_id': 'snpseq00025',
-                        'ngi_project_name': 'AB-1234',
+                        'delivery_project_id': dds_project_id,
+                        'ngi_project_name': project_name,
                         'dds': True,
                         'auth_token': '1234',
                         'skip_delivery': False,
@@ -309,6 +359,23 @@ class TestIntegrationDDSShortWait(BaseIntegration):
             self._create_projects_dir_with_random_data(tmp_dir)
             self._create_checksums_file(tmp_dir)
 
+            project_name = "AB-1234"
+            url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+            payload = {
+                "description": "Dummy project",
+                "pi": "alex@doe.com",
+                "researchers": ["robin@doe.com", "kim@doe.com"],
+                "owners": ["alex@doe.com"],
+                "auth_token": '1234',
+            }
+
+            response = yield self.http_client.fetch(
+                    self.get_url(url), method='POST',
+                    body=json.dumps(payload))
+
+            self.assertEqual(response.code, 202)
+            dds_project_id = json.loads(response.body)["dds_project_id"]
+
             url = "/".join([self.API_BASE, "stage", "runfolder", dir_name])
             response = yield self.http_client.fetch(
                     self.get_url(url),
@@ -323,8 +390,8 @@ class TestIntegrationDDSShortWait(BaseIntegration):
                 delivery_url = '/'.join([
                     self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
-                        'delivery_project_id': 'snpseq00025',
-                        'ngi_project_name': 'AB-1234',
+                        'delivery_project_id': dds_project_id,
+                        'ngi_project_name': project_name,
                         'dds': True,
                         'auth_token': '1234',
                         'skip_delivery': False,
@@ -366,6 +433,23 @@ class TestIntegrationDDSLongWait(BaseIntegration):
                 dir='./tests/resources/runfolders/',
                 prefix='160930_ST-E00216_0111_BH37CWALXX_') as tmp_dir:
 
+            project_name = "CD-1234"
+            url = "/".join([self.API_BASE, "dds_project", "create", project_name])
+            payload = {
+                "description": "Dummy project",
+                "pi": "alex@doe.com",
+                "researchers": ["robin@doe.com", "kim@doe.com"],
+                "owners": ["alex@doe.com"],
+                "auth_token": '1234',
+            }
+
+            response = yield self.http_client.fetch(
+                    self.get_url(url), method='POST',
+                    body=json.dumps(payload))
+
+            self.assertEqual(response.code, 202)
+            dds_project_id = json.loads(response.body)["dds_project_id"]
+
             dir_name = os.path.basename(tmp_dir)
             self._create_projects_dir_with_random_data(tmp_dir)
             self._create_checksums_file(tmp_dir)
@@ -383,8 +467,8 @@ class TestIntegrationDDSLongWait(BaseIntegration):
                 delivery_url = '/'.join([
                     self.API_BASE, 'deliver', 'stage_id', str(staging_id)])
                 delivery_body = {
-                        'delivery_project_id': 'snpseq00025',
-                        'ngi_project_name': 'AB-1234',
+                        'delivery_project_id': dds_project_id,
+                        'ngi_project_name': project_name,
                         'dds': True,
                         'auth_token': '1234',
                         'skip_delivery': False,

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -40,6 +40,7 @@ class TestDDSService(AsyncTestCase):
 
         self.mock_dds_delivery_repo = MagicMock()
         self.mock_dds_put_repo = MagicMock()
+        self.mock_dds_put_repo.get_dds_put_by_status.return_value = None
 
         self.delivery_order = DeliveryOrder(
                 id=1,

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -95,7 +95,6 @@ class TestDDSService(AsyncTestCase):
             with patch(
                     'delivery.models.project'
                     '.DDSProject.get_ngi_project_name',
-                    new_callable=AsyncMock,
                     return_value='AB-1234'):
                 yield dds_project.deliver(
                         staging_id=1,
@@ -159,7 +158,6 @@ class TestDDSService(AsyncTestCase):
             with patch(
                     'delivery.models.project'
                     '.DDSProject.get_ngi_project_name',
-                    new_callable=AsyncMock,
                     return_value='AB-1234'):
                 yield dds_project.deliver(
                         staging_id=1,
@@ -218,7 +216,6 @@ class TestDDSService(AsyncTestCase):
             with patch(
                     'delivery.models.project'
                     '.DDSProject.get_ngi_project_name',
-                    new_callable=AsyncMock,
                     return_value='AB-1234'):
                 yield dds_project.deliver(staging_id=1)
 
@@ -238,7 +235,6 @@ class TestDDSService(AsyncTestCase):
             with patch(
                     'delivery.models.project'
                     '.DDSProject.get_ngi_project_name',
-                    new_callable=AsyncMock,
                     return_value='AB-1234'):
                 yield dds_project.deliver(staging_id=1)
 
@@ -274,7 +270,6 @@ class TestDDSService(AsyncTestCase):
         with patch(
                 'delivery.models.project'
                 '.DDSProject.get_ngi_project_name',
-                new_callable=AsyncMock,
                 return_value='AB-1234'):
             yield dds_project.deliver(staging_id=1, skip_delivery=True)
 
@@ -408,5 +403,5 @@ project"""
                     dds_project_id=mock_dds_project[0]["Project ID"],
                     )
 
-            ngi_project_name = yield dds_project.get_ngi_project_name()
+            ngi_project_name = dds_project.get_ngi_project_name()
             self.assertEqual(ngi_project_name, "AB-1234")

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -97,7 +97,7 @@ class TestDDSService(AsyncTestCase):
                     '.DDSProject.get_ngi_project_name',
                     new_callable=AsyncMock,
                     return_value='AB-1234'):
-                yield dds_project.put(
+                yield dds_project.deliver(
                         staging_id=1,
                         deadline=deadline,
                         )
@@ -161,7 +161,7 @@ class TestDDSService(AsyncTestCase):
                     '.DDSProject.get_ngi_project_name',
                     new_callable=AsyncMock,
                     return_value='AB-1234'):
-                yield dds_project.put(
+                yield dds_project.deliver(
                         staging_id=1,
                         deadline=deadline,
                         release=False,
@@ -220,7 +220,7 @@ class TestDDSService(AsyncTestCase):
                     '.DDSProject.get_ngi_project_name',
                     new_callable=AsyncMock,
                     return_value='AB-1234'):
-                yield dds_project.put(staging_id=1)
+                yield dds_project.deliver(staging_id=1)
 
     @gen_test
     def test_dds_put_raises_on_non_successful_stage_id(self):
@@ -240,7 +240,7 @@ class TestDDSService(AsyncTestCase):
                     '.DDSProject.get_ngi_project_name',
                     new_callable=AsyncMock,
                     return_value='AB-1234'):
-                yield dds_project.put(staging_id=1)
+                yield dds_project.deliver(staging_id=1)
 
     def test_delivery_order_by_id(self):
         delivery_order = DeliveryOrder(
@@ -276,7 +276,7 @@ class TestDDSService(AsyncTestCase):
                 '.DDSProject.get_ngi_project_name',
                 new_callable=AsyncMock,
                 return_value='AB-1234'):
-            yield dds_project.put(staging_id=1, skip_delivery=True)
+            yield dds_project.deliver(staging_id=1, skip_delivery=True)
 
         def _get_delivery_order():
             return self.delivery_order.delivery_status

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -38,6 +38,9 @@ class TestDDSService(AsyncTestCase):
         self.mock_staging_service = MagicMock()
         self.mock_delivery_repo = MagicMock()
 
+        self.mock_dds_delivery_repo = MagicMock()
+        self.mock_dds_put_repo = MagicMock()
+
         self.delivery_order = DeliveryOrder(
                 id=1,
                 delivery_source="/staging/dir/bar",
@@ -56,6 +59,8 @@ class TestDDSService(AsyncTestCase):
                 staging_service=self.mock_staging_service,
                 staging_dir='/foo/bar/staging_dir',
                 delivery_repo=self.mock_delivery_repo,
+                dds_delivery_repo=self.mock_dds_delivery_repo,
+                dds_put_repo=self.mock_dds_put_repo,
                 session_factory=self.mock_session_factory,
                 dds_conf=self.mock_dds_config,
                 )
@@ -379,29 +384,3 @@ project"""
             '--deadline', deadline,
             '--no-mail',
             ])
-
-    @gen_test
-    def test_get_dds_project_title(self):
-        mock_dds_project = [{
-                "Access": True,
-                "Last updated": "Fri, 01 Jul 2022 14:31:13 CEST",
-                "PI": "pi@email.com",
-                "Project ID": "snpseq00025",
-                "Size": 25856185058,
-                "Status": "In Progress",
-                "Title": "AB1234"
-                }]
-
-        with patch(
-                'delivery.models.project.DDSProject._run',
-                new_callable=AsyncMock,
-                return_value=json.dumps(mock_dds_project),
-                ):
-            dds_project = DDSProject(
-                    dds_service=self.dds_service,
-                    auth_token=self.token_file.name,
-                    dds_project_id=mock_dds_project[0]["Project ID"],
-                    )
-
-            ngi_project_name = dds_project.get_ngi_project_name()
-            self.assertEqual(ngi_project_name, "AB-1234")


### PR DESCRIPTION
## What problems does this PR solve?
The delivery system has been switched to DDS. This program provides an option to upload files to a specific location. This makes the staging step unnecessary. Skipping this step would both reduce delivery times and simplify the code 

The delivery service supports three delivery modes: project, runfolder, and runfolder for projects. This PR introduces a new delivery route for projects (the simplest case). The goal is to test if this works as expected and to gather feedback before we apply this change to the other (more complex) delivery modes. All former delivery routes remain available.

Some design questions to think about:
- when using mover we needed an option to skip the delivery step (see [this comment](https://github.com/arteria-project/arteria-delivery/blob/46830f5b891dabb3a1352719842d1a9706641032/tests/integration_tests/test_integration.py#L136)), but this is not strictly necessary anymore since:
    1. dds is available everywhere (and if not it is easily installable from PyPI)
    2. Whenever possible it is better to test the full delivery workflow before releasing to production
As it is now, I have not implemented the `skip_delivery` option, is this something we want to keep?

## Risk analysis:
- This implementation relies on two new table in the database and uses them to determine if a project has been delivered before. There is a risk that project are delivered twice if different delivery routes are used. Maybe this could be fixed by looking into both tables, I can look into that and add to this PR if I manage to fix it.

## How has the changes been tested?
In addition to automatic tests, has any manual testing been carried out? Unit tests and integration tests have been updated.

## Reasons for careful code review
If any of the boxes below are checked, extra careful code review should be initiated.

  - [ ] This PR contains code that could remove data
