### PR TITLE
Bio 2359 yaml config parser

### DIFF
--- a/config/organise_config/organise_project.yml
+++ b/config/organise_config/organise_project.yml
@@ -17,8 +17,15 @@ files_to_organise:
   options: 
     required: True
     link_type: "copy"
-- source: "{runfolderpath}/*/Projects/{inputkey}"
-  destination: "{deliverypath}/fastq/"
+- source: "{runfolderpath}/*/Projects/{inputkey}/*"
+  destination: "{deliverypath}/fastq/{runfoldername}/{samplename}/"
   options: 
     required: True
     link_type: "softlink"
+    filter: "{runfolderpath}/(?P<runfoldername>[^/]+)/Projects/{inputkey}/(?P=runfoldername)/(?P<samplename>[^/]+)/"
+- source: "{runfolderpath}/*/Projects/{inputkey}/*"
+  destination: "{deliverypath}/fastq/{runfoldername}/"
+  options: 
+    required: True
+    link_type: "softlink"
+    filter: "{runfolderpath}/(?P<runfoldername>[^/]+)/Projects/{inputkey}/(?P=runfoldername)/(?P=runfoldername)_{inputkey}_multiqc_report[\\w.-]+"

--- a/config/organise_config/organise_project.yml
+++ b/config/organise_config/organise_project.yml
@@ -11,7 +11,7 @@ files_to_organise:
   options: 
     required: True
     link_type: "softlink" 
-- source: "{deliverypath}/softlinks/DELIVERY.README.RNASEQ.md"
+- source: "{rootpath}/DELIVERY/softlinks/DELIVERY.README.RNASEQ.md"
   destination: "{deliverypath}/DELIVERY.README.RNASEQ.md"
   options: 
     required: True

--- a/config/organise_config/organise_project.yml
+++ b/config/organise_config/organise_project.yml
@@ -1,22 +1,22 @@
 # Analysis results, readme and runfolder/runfolders.
 #Input: PROJECTID
-rootpath: /proj/ngi2016001/nobackup/NGI
-runfolderpath: /proj/ngi2016001/incoming
-analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
-deliverypath: <ROOTPATH>/DELIVERY/<PROJECTID>
+rootpath: "/proj/ngi2016001/nobackup/NGI"
+runfolderpath: "/proj/ngi2016001/incoming"
+analysispath: "{rootpath}/ANALYSIS/{projectid}"
+deliverypath: "{rootpath}/DELIVERY/{projectid}"
 files_to_deliver:
-- source: <ANALYSISPATH>/results
-  destination: <DELIVERYPATH>/results
+- source: "{analysispath}/results"
+  destination: "{deliverypath}/results"
   options: 
     required: True
     symlink: True 
-- source: <DELIVERYPATH>/softlinks/DELIVERY.README.RNASEQ.md
-  destination: <DELIVERYPATH>/DELIVERY.README.RNASEQ.md
+- source: "{deliverypath}/softlinks/DELIVERY.README.RNASEQ.md"
+  destination: "{deliverypath}/DELIVERY.README.RNASEQ.md"
   options: 
     required: True
     symlink: True
-- source: <RUNFOLDERPATH>/*/Projects/<PROJECTID>
-  destination: <DELIVERYPATH>/fastq/
+- source: "{runfolderpath}/*/Projects/{projectid}"
+  destination: "{deliverypath}/fastq/"
   options: 
     required: True
     symlink: True

--- a/config/organise_config/organise_project.yml
+++ b/config/organise_config/organise_project.yml
@@ -1,0 +1,22 @@
+# Analysis results, readme and runfolder/runfolders.
+#Input: PROJECTID
+rootpath: /proj/ngi2016001/nobackup/NGI
+runfolderpath: /proj/ngi2016001/incoming
+analysispath: <ROOTPATH>/ANALYSIS/<PROJECTID>
+deliverypath: <ROOTPATH>/DELIVERY/<PROJECTID>
+files_to_deliver:
+- source: <ANALYSISPATH>/results
+  destination: <DELIVERYPATH>/results
+  options: 
+    required: True
+    symlink: True 
+- source: <DELIVERYPATH>/softlinks/DELIVERY.README.RNASEQ.md
+  destination: <DELIVERYPATH>/DELIVERY.README.RNASEQ.md
+  options: 
+    required: True
+    symlink: True
+- source: <RUNFOLDERPATH>/*/Projects/<PROJECTID>
+  destination: <DELIVERYPATH>/fastq/
+  options: 
+    required: True
+    symlink: True

--- a/config/organise_config/organise_project.yml
+++ b/config/organise_config/organise_project.yml
@@ -1,10 +1,11 @@
 # Analysis results, readme and runfolder/runfolders.
 #Input: PROJECTID
 variables:
+  inputkey: "projectid"
   rootpath: "/proj/ngi2016001/nobackup/NGI"
   runfolderpath: "/proj/ngi2016001/incoming"
-  analysispath: "{rootpath}/ANALYSIS/{projectid}"
-  deliverypath: "{rootpath}/DELIVERY/{projectid}"
+  analysispath: "{rootpath}/ANALYSIS/{inputkey}"
+  deliverypath: "{rootpath}/DELIVERY/{inputkey}"
 files_to_organise:
 - source: "{analysispath}/results"
   destination: "{deliverypath}/results"
@@ -15,8 +16,8 @@ files_to_organise:
   destination: "{deliverypath}/DELIVERY.README.RNASEQ.md"
   options: 
     required: True
-    link_type: "softlink"
-- source: "{runfolderpath}/*/Projects/{projectid}"
+    link_type: "copy"
+- source: "{runfolderpath}/*/Projects/{inputkey}"
   destination: "{deliverypath}/fastq/"
   options: 
     required: True

--- a/config/organise_config/organise_project.yml
+++ b/config/organise_config/organise_project.yml
@@ -1,22 +1,23 @@
 # Analysis results, readme and runfolder/runfolders.
 #Input: PROJECTID
-rootpath: "/proj/ngi2016001/nobackup/NGI"
-runfolderpath: "/proj/ngi2016001/incoming"
-analysispath: "{rootpath}/ANALYSIS/{projectid}"
-deliverypath: "{rootpath}/DELIVERY/{projectid}"
-files_to_deliver:
+variables:
+  rootpath: "/proj/ngi2016001/nobackup/NGI"
+  runfolderpath: "/proj/ngi2016001/incoming"
+  analysispath: "{rootpath}/ANALYSIS/{projectid}"
+  deliverypath: "{rootpath}/DELIVERY/{projectid}"
+files_to_organise:
 - source: "{analysispath}/results"
   destination: "{deliverypath}/results"
   options: 
     required: True
-    symlink: True 
+    link_type: "softlink" 
 - source: "{deliverypath}/softlinks/DELIVERY.README.RNASEQ.md"
   destination: "{deliverypath}/DELIVERY.README.RNASEQ.md"
   options: 
     required: True
-    symlink: True
+    link_type: "softlink"
 - source: "{runfolderpath}/*/Projects/{projectid}"
   destination: "{deliverypath}/fastq/"
   options: 
     required: True
-    symlink: True
+    link_type: "softlink"

--- a/config/organise_config/organise_runfolder.yml
+++ b/config/organise_config/organise_runfolder.yml
@@ -2,9 +2,10 @@
 #Input: runfolder_name
 
 #Currently named runfolderpath and runfolder to harmonize with rnaseq config by Monika, but for specific runfolder delivery, technically, these could be "merged" to one.
-variables:  
+variables:
+  inputkey: "runfolder_name"  
   runfolderpath: "/proj/ngi2016001/incoming"
-  runfolder: "{runfolderpath}/{runfolder_name}"
+  runfolder: "{runfolderpath}/{inputkey}"
   organised: "{runfolder}/Projects"
 
 #current path is /proj/ngi2016001/incoming/<RUNFOLDER>/Projects/<PROJECT>/<RUNFOLDER>/
@@ -13,7 +14,7 @@ files_to_organise:
 
 #The fastq files
 - source: "{runfolder}/Unaligned/*"  
-  destination: "{organised}/{projectid}/{runfolder_name}/Sample_{samplename}/"
+  destination: "{organised}/{projectid}/{inputkey}/Sample_{samplename}/"
   options:
     required: True
     link_type: "softlink"
@@ -21,11 +22,11 @@ files_to_organise:
 
 #The MultiQC files
 - source: "{runfolder}/seqreports/project/*"
-  destination: "{organised}/{projectid}/{runfolder_name}/"
+  destination: "{organised}/{projectid}/{inputkey}/"
   options:
     required: True
     link_type: "softlink"
-    filter: (?P<projectid>[\w-]+)/{runfolder_name}_(?P=projectid)_multiqc_report[\w.-]+
+    filter: (?P<projectid>[\w-]+)/{inputkey}_(?P=projectid)_multiqc_report[\w.-]+
 
 
 

--- a/config/organise_config/organise_runfolder.yml
+++ b/config/organise_config/organise_runfolder.yml
@@ -3,28 +3,28 @@
 
 #Currently named runfolderpath and runfolder to harmonize with rnaseq config by Monika, but for specific runfolder delivery, technically, these could be "merged" to one.
 runfolderpath: /proj/ngi2016001/incoming
-runfolder: <RUNFOLDERPATH>/<RUNFOLDER_NAME>
-organised: <RUNFOLDER>/Projects/
+runfolder: {runfolderpath}/{runfolder_name}
+organised: {runfolder}/Projects/
 
 #current path is /proj/ngi2016001/incoming/<RUNFOLDER>/Projects/<PROJECT>/<RUNFOLDER>/
 #The following is based on that we are to keep the same directory structure as above.
 files_to_organize:
 
   #The fastq files
-  - source: <RUNFOLDER>/Unaligned/*  
-    destination: <ORGANISED>/(?P=projectid)/<RUNFOLDER_NAME>/Sample_(?P=samplename)/
+  - source: {runfolder}/Unaligned/*  
+    destination: {organised}/{projectid}/{runfolder_name}/Sample_{samplename}/
     options:
       required: True
       symlink: True
       regexp: (?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz
 
    #The MultiQC files
-   - source: <RUNFOLDER>/seqreports/project/*
-     destination: <ORGANISED>/(?P=projectid)/<RUNFOLDER_NAME>/
+   - source: {runfolder}/seqreports/project/*
+     destination: {organised}/{projectid}/{runfolder_name}/
      options:
        required: True
        symlink: True
-       regexp: (?P<projectid>[\w-]+)/(?P<RUNFOLDER_NAME>\w+)_(?P=projectid)_multiqc_report[\w.-]+
+       regexp: (?P<projectid>[\w-]+)/(?P{runfolder_name}\w+)_(?P=projectid)_multiqc_report[\w.-]+
 
 
 

--- a/config/organise_config/organise_runfolder.yml
+++ b/config/organise_config/organise_runfolder.yml
@@ -18,15 +18,15 @@ files_to_organise:
   options:
     required: True
     link_type: "softlink"
-    filter: (?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz
+    filter: "(?P<projectid>[\\w-]+)/Sample_(?P<samplename>[\\w-]+)/(?P=samplename)_S(?P<samplenumber>\\d+)_L(?P<lanes>\\d+)_R(?P<read>\\d)_001.fastq.gz"
 
 #The MultiQC files
-- source: "{runfolder}/seqreports/project/*"
+- source: "{runfolder}/seqreports/projects/*"
   destination: "{organised}/{projectid}/{inputkey}/"
   options:
     required: True
     link_type: "softlink"
-    filter: (?P<projectid>[\w-]+)/{inputkey}_(?P=projectid)_multiqc_report[\w.-]+
+    filter: "(?P<projectid>[\\w-]+)/{inputkey}_(?P=projectid)_multiqc_report[\\w.-]+"
 
 
 

--- a/config/organise_config/organise_runfolder.yml
+++ b/config/organise_config/organise_runfolder.yml
@@ -2,29 +2,30 @@
 #Input: runfolder_name
 
 #Currently named runfolderpath and runfolder to harmonize with rnaseq config by Monika, but for specific runfolder delivery, technically, these could be "merged" to one.
-runfolderpath: "/proj/ngi2016001/incoming"
-runfolder: "{runfolderpath}/{runfolder_name}"
-organised: "{runfolder}/Projects/"
+variables:  
+  runfolderpath: "/proj/ngi2016001/incoming"
+  runfolder: "{runfolderpath}/{runfolder_name}"
+  organised: "{runfolder}/Projects"
 
 #current path is /proj/ngi2016001/incoming/<RUNFOLDER>/Projects/<PROJECT>/<RUNFOLDER>/
 #The following is based on that we are to keep the same directory structure as above.
-files_to_organize:
+files_to_organise:
 
 #The fastq files
 - source: "{runfolder}/Unaligned/*"  
   destination: "{organised}/{projectid}/{runfolder_name}/Sample_{samplename}/"
   options:
     required: True
-    symlink: True
-    regexp: (?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz
+    link_type: "softlink"
+    filter: (?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz
 
 #The MultiQC files
 - source: "{runfolder}/seqreports/project/*"
   destination: "{organised}/{projectid}/{runfolder_name}/"
   options:
     required: True
-    symlink: True
-    regexp: (?P<projectid>[\w-]+)/(?P{runfolder_name}\w+)_(?P=projectid)_multiqc_report[\w.-]+
+    link_type: "softlink"
+    filter: (?P<projectid>[\w-]+)/{runfolder_name}_(?P=projectid)_multiqc_report[\w.-]+
 
 
 

--- a/config/organise_config/organise_runfolder.yml
+++ b/config/organise_config/organise_runfolder.yml
@@ -2,29 +2,29 @@
 #Input: runfolder_name
 
 #Currently named runfolderpath and runfolder to harmonize with rnaseq config by Monika, but for specific runfolder delivery, technically, these could be "merged" to one.
-runfolderpath: /proj/ngi2016001/incoming
-runfolder: {runfolderpath}/{runfolder_name}
-organised: {runfolder}/Projects/
+runfolderpath: "/proj/ngi2016001/incoming"
+runfolder: "{runfolderpath}/{runfolder_name}"
+organised: "{runfolder}/Projects/"
 
 #current path is /proj/ngi2016001/incoming/<RUNFOLDER>/Projects/<PROJECT>/<RUNFOLDER>/
 #The following is based on that we are to keep the same directory structure as above.
 files_to_organize:
 
-  #The fastq files
-  - source: {runfolder}/Unaligned/*  
-    destination: {organised}/{projectid}/{runfolder_name}/Sample_{samplename}/
-    options:
-      required: True
-      symlink: True
-      regexp: (?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz
+#The fastq files
+- source: "{runfolder}/Unaligned/*"  
+  destination: "{organised}/{projectid}/{runfolder_name}/Sample_{samplename}/"
+  options:
+    required: True
+    symlink: True
+    regexp: (?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz
 
-   #The MultiQC files
-   - source: {runfolder}/seqreports/project/*
-     destination: {organised}/{projectid}/{runfolder_name}/
-     options:
-       required: True
-       symlink: True
-       regexp: (?P<projectid>[\w-]+)/(?P{runfolder_name}\w+)_(?P=projectid)_multiqc_report[\w.-]+
+#The MultiQC files
+- source: "{runfolder}/seqreports/project/*"
+  destination: "{organised}/{projectid}/{runfolder_name}/"
+  options:
+    required: True
+    symlink: True
+    regexp: (?P<projectid>[\w-]+)/(?P{runfolder_name}\w+)_(?P=projectid)_multiqc_report[\w.-]+
 
 
 

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -7,12 +7,12 @@ import yaml
 import json
 import re
 
-#from delivery.exceptions import ProjectAlreadyOrganisedException
+from delivery.exceptions import ProjectAlreadyOrganisedException
 
-#from delivery.models.project import RunfolderProject
-#from delivery.models.runfolder import Runfolder, RunfolderFile
-#from delivery.models.sample import Sample, SampleFile
-#from delivery.services.file_system_service import FileSystemService
+from delivery.models.project import RunfolderProject
+from delivery.models.runfolder import Runfolder, RunfolderFile
+from delivery.models.sample import Sample, SampleFile
+from delivery.services.file_system_service import FileSystemService
 
 log = logging.getLogger(__name__)
 
@@ -24,8 +24,7 @@ class OrganiseService(object):
     This service handles that in a synchronous way.
     """
 
-    #def __init__(self, runfolder_service, file_system_service=FileSystemService()):
-    def __init__(self, runfolder_service, file_system_service=None):
+    def __init__(self, runfolder_service, file_system_service=FileSystemService()):
         """
         Instantiate a new OrganiseService
         :param runfolder_service: an instance of a RunfolderService

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -301,16 +301,3 @@ class OrganiseService(object):
 class Default(dict):
     def __missing__(self, key):
         return f"{{{key}}}"
-
-
-
-if __name__ == "__main__":
-    config_file_path = sys.argv[1]
-    input_key = sys.argv[2]
-    input_value = sys.argv[3]
-
-    if not os.path.exists(config_file_path):
-        raise Exception("Config file does not exist.")
-
-    config_as_list = OrganiseService.parse_yaml_config(config_file_path=config_file_path , input_key=input_key, input_value=input_value)
-    

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -18,13 +18,18 @@ log = logging.getLogger(__name__)
 
 class OrganiseService(object):
     """
-    Starting in this context means organising a runfolder in preparation for a delivery. Each project on the runfolder
-    will be organised into its own separate directory. Sequence and report files will be symlinked from their original
+    Starting in this context means organising a runfolder in preparation
+    for a delivery. Each project on the runfolder
+    will be organised into its own separate directory. 
+    Sequence and report files will be symlinked from their original
     location.
     This service handles that in a synchronous way.
     """
-
-    def __init__(self, runfolder_service, file_system_service=FileSystemService()):
+    def __init__(
+            self, 
+            runfolder_service, 
+            file_system_service=FileSystemService()
+            ):
         """
         Instantiate a new OrganiseService
         :param runfolder_service: an instance of a RunfolderService
@@ -35,30 +40,45 @@ class OrganiseService(object):
 
     def organise_runfolder(self, runfolder_id, lanes, projects, force):
         """
-        Organise a runfolder in preparation for delivery. This will create separate subdirectories for each of the
-        projects and symlink all files belonging to the project to be delivered under this directory.
+        Organise a runfolder in preparation for delivery. 
+        This will create separate subdirectories for each of the
+        projects and symlink all files belonging to the project 
+        to be delivered under this directory.
 
         :param runfolder_id: the name of the runfolder to be organised
-        :param lanes: if not None, only samples on any of the specified lanes will be organised
-        :param projects: if not None, only projects in this list will be organised
-        :param force: if True, a previously organised project will be renamed with a unique suffix
-        :raises ProjectAlreadyOrganisedException: if a project has already been organised and force is False
+        :param lanes: if not None, only samples on any of the 
+        specified lanes will be organised
+        :param projects: if not None, only projects in this 
+        list will be organised
+        :param force: if True, a previously organised project will be 
+        renamed with a unique suffix
+        :raises ProjectAlreadyOrganisedException: if a project has 
+        already been organised and force is False
         :return: a Runfolder instance representing the runfolder after organisation
         """
         # retrieve a runfolder object and project objects to be organised
         runfolder = self.runfolder_service.find_runfolder(runfolder_id)
         projects_on_runfolder = list(
-            self.runfolder_service.find_projects_on_runfolder(runfolder, only_these_projects=projects))
+            self.runfolder_service.find_projects_on_runfolder(
+                runfolder, 
+                only_these_projects=projects))
 
         # handle previously organised projects
         organised_projects_path = os.path.join(runfolder.path, "Projects")
         for project in projects_on_runfolder:
-            self.check_previously_organised_project(project, organised_projects_path, force)
+            self.check_previously_organised_project(
+                project, 
+                organised_projects_path, 
+                force)
 
         # organise the projects and return a new Runfolder instance
         organised_projects = []
         for project in projects_on_runfolder:
-            organised_projects.append(self.organise_project(runfolder, project, organised_projects_path, lanes))
+            organised_projects.append(self.organise_project(
+                runfolder, 
+                project, 
+                organised_projects_path, 
+                lanes))
 
         return Runfolder(
             runfolder.name,
@@ -66,8 +86,15 @@ class OrganiseService(object):
             projects=organised_projects,
             checksums=runfolder.checksums)
 
-    def check_previously_organised_project(self, project, organised_projects_path, force):
-        organised_project_path = os.path.join(organised_projects_path, project.name)
+    def check_previously_organised_project(
+            self, 
+            project, 
+            organised_projects_path, 
+            force
+            ):
+        organised_project_path = os.path.join(
+            organised_projects_path, 
+            project.name)
         if self.file_system_service.exists(organised_project_path):
             msg = "Organised project path '{}' already exists".format(organised_project_path)
             if not force:
@@ -82,22 +109,39 @@ class OrganiseService(object):
                 self.file_system_service.mkdir(organised_projects_backup_path)
             self.file_system_service.rename(organised_project_path, backup_path)
 
-    def organise_project(self, runfolder, project, organised_projects_path, lanes):
+    def organise_project(
+            self, 
+            runfolder, 
+            project, 
+            organised_projects_path, 
+            lanes
+            ):
         """
-        Organise a project on a runfolder into its own directory and into a standard structure. If the project has
-        already been organised, a ProjectAlreadyOrganisedException will be raised, unless force is True. If force is
+        Organise a project on a runfolder into its own directory and 
+        into a standard structure. If the project has
+        already been organised, a ProjectAlreadyOrganisedException will 
+        be raised, unless force is True. If force is
         True, the existing project path will be renamed with a unique suffix.
 
-        :param runfolder: a Runfolder instance representing the runfolder on which the project belongs
-        :param project: a Project instance representing the project to be organised
-        :param lanes: if not None, only samples on any of the specified lanes will be organised
-        :param force: if True, a previously organised project will be renamed with a unique suffix
-        :raises ProjectAlreadyOrganisedException: if project has already been organised and force is False
+        :param runfolder: a Runfolder instance representing the runfolder 
+        on which the project belongs
+        :param project: a Project instance representing the project 
+        to be organised
+        :param lanes: if not None, only samples on any of the 
+        specified lanes will be organised
+        :param force: if True, a previously organised project will be 
+        renamed with a unique suffix
+        :raises ProjectAlreadyOrganisedException: if project has 
+        already been organised and force is False
         :return: a Project instance representing the project after organisation
         """
         # symlink the samples
-        organised_project_path = os.path.join(organised_projects_path, project.name)
-        organised_project_runfolder_path = os.path.join(organised_project_path, runfolder.name)
+        organised_project_path = os.path.join(
+            organised_projects_path, 
+            project.name)
+        organised_project_runfolder_path = os.path.join(
+            organised_project_path, 
+            runfolder.name)
         organised_samples = []
         for sample in project.samples:
             organised_samples.append(
@@ -108,7 +152,8 @@ class OrganiseService(object):
         # symlink the project files
         organised_project_files = []
         if project.project_files:
-            project_file_base = self.file_system_service.dirname(project.project_files[0].file_path)
+            project_file_base = self.file_system_service.dirname(
+                project.project_files[0].file_path)
             for project_file in project.project_files:
                 organised_project_files.append(
                     self.organise_project_file(
@@ -131,12 +176,18 @@ class OrganiseService(object):
 
         return organised_project
 
-    def organise_project_file(self, project_file, organised_project_path, project_file_base=None):
+    def organise_project_file(
+            self, 
+            project_file, 
+            organised_project_path, 
+            project_file_base=None):
         """
         Find and symlink the project report to the organised project directory.
 
-        :param project: a Project instance representing the project before organisation
-        :param organised_project: a Project instance representing the project after organisation
+        :param project: a Project instance representing the 
+        project before organisation
+        :param organised_project: a Project instance representing the 
+        project after organisation
         """
         project_file_base = project_file_base or self.file_system_service.dirname(project_file.file_path)
 
@@ -153,26 +204,41 @@ class OrganiseService(object):
         self.file_system_service.symlink(link_path, link_name)
         return RunfolderFile(link_name, file_checksum=project_file.checksum)
 
-    def organise_sample(self, sample, organised_project_path, lanes):
+    def organise_sample(
+            self, 
+            sample, 
+            organised_project_path, 
+            lanes):
         """
-        Organise a sample into its own directory under the corresponding project directory. Samples can be excluded
-        from organisation based on which lane they were run on. The sample directory will be named identically to the
-        sample id field. This may be different from the sample name field which is used as a prefix in the file name
-        for the sample files. This is the same behavior as e.g. bcl2fastq uses for sample id and sample name.
+        Organise a sample into its own directory under the 
+        corresponding project directory. Samples can be excluded
+        from organisation based on which lane they were run on. 
+        The sample directory will be named identically to the
+        sample id field. This may be different from the 
+        sample name field which is used as a prefix in the file name
+        for the sample files. This is the same behavior 
+        as e.g. bcl2fastq uses for sample id and sample name.
 
         :param sample: a Sample instance representing the sample to be organised
-        :param organised_project_path: the path to the organised project directory under which to place the sample
-        :param lanes: if not None, only samples run on the any of the specified lanes will be organised
+        :param organised_project_path: the path to the organised 
+        project directory under which to place the sample
+        :param lanes: if not None, only samples run on the any of the 
+        specified lanes will be organised
         :return: a new Sample instance representing the sample after organisation
         """
 
         # symlink each sample in its own directory
-        organised_sample_path = os.path.join(organised_project_path, sample.sample_id)
+        organised_sample_path = os.path.join(
+            organised_project_path, 
+            sample.sample_id)
 
         # symlink the sample files using relative paths
         organised_sample_files = []
         for sample_file in sample.sample_files:
-            organised_sample_files.append(self.organise_sample_file(sample_file, organised_sample_path, lanes))
+            organised_sample_files.append(self.organise_sample_file(
+                sample_file, 
+                organised_sample_path, 
+                lanes))
 
         # clean up the list of sample files by removing None elements
         organised_sample_files = list(filter(None, organised_sample_files))
@@ -183,24 +249,39 @@ class OrganiseService(object):
             sample_id=sample.sample_id,
             sample_files=organised_sample_files)
 
-    def organise_sample_file(self, sample_file, organised_sample_path, lanes):
+    def organise_sample_file(
+            self, 
+            sample_file, 
+            organised_sample_path, 
+            lanes):
         """
-        Organise a sample file by creating a relative symlink in the supplied directory, pointing back to the supplied
-        SampleFile's original file path. The Sample file can be excluded from organisation based on the lane it was
-        derived from. The supplied directory will be created if it doesn't exist.
+        Organise a sample file by creating a relative symlink 
+        in the supplied directory, pointing back to the supplied
+        SampleFile's original file path. 
+        The Sample file can be excluded from organisation based on 
+        the lane it was derived from. 
+        The supplied directory will be created if it doesn't exist.
 
-        :param sample_file: a SampleFile instance representing the sample file to be organised
-        :param organised_sample_path: the path to the organised sample directory under which to place the symlink
-        :param lanes: if not None, only sample files derived from any of the specified lanes will be organised
-        :return: a new SampleFile instance representing the sample file after organisation
+        :param sample_file: a SampleFile instance representing the 
+        sample file to be organised
+        :param organised_sample_path: the path to the 
+        organised sample directory under which to place the symlink
+        :param lanes: if not None, only sample files 
+        derived from any of the specified lanes will be organised
+        :return: a new SampleFile instance representing the 
+        sample file after organisation
         """
-        # skip if the sample file data is derived from a lane that shouldn't be included
+        # skip if the sample file data is derived from 
+        # a lane that shouldn't be included
         if lanes and sample_file.lane_no not in lanes:
             return None
 
-        # create the symlink in the supplied directory and relative to the file's original location
+        # create the symlink in the supplied directory and 
+        # relative to the file's original location
         link_name = os.path.join(organised_sample_path, sample_file.file_name)
-        relative_path = self.file_system_service.relpath(sample_file.file_path, organised_sample_path)
+        relative_path = self.file_system_service.relpath(
+            sample_file.file_path, 
+            organised_sample_path)
         self.file_system_service.symlink(relative_path, link_name)
         return SampleFile(
             link_name,
@@ -211,91 +292,195 @@ class OrganiseService(object):
             is_index=sample_file.is_index,
             checksum=sample_file.checksum)
 
-    def parse_yaml_config(config_file_path, input_key, input_value):
+    @staticmethod
+    def load_yaml_config(config_file_path):
         """
-        Read a configuration file for organizing a runfolder or analyzed project prior to delivery. 
-        This function will do string substitutions based on the input, keys in the configuration file
-         and results from resolved regular expressions (based on patterns from the configuration file). 
-
-        :param config_file_path: Full path to a configuration file in yaml-format.
-        :param input_key: projectid or runfolder_name
-        :param input_value: A runfolder name or a project name (for analysed projects).
-        :return: A list with one element per link/copy operation to be performed during organisation.
-         Each element consist of a tuple with 3 values ("path/to/source/file", "path/to/destination/file", "options as dictionary").
+        Open and read yaml configuration file for 
+        organising runfolders or projects.
+        :param config_file_path: /path/to/config.yaml
+        :return: Config as dict. 
         """
-
         with open(config_file_path) as f:
-            config = yaml.load(f, Loader=yaml.SafeLoader)
+            config_as_dict = yaml.load(f, Loader=yaml.SafeLoader)
 
-        input_dict = {}
-        input_dict[input_key] = input_value
-        input_dict.update(config["variables"]) #The input variable must be the first occuring key.
-        config["variables"] = input_dict
+        return config_as_dict
+    
+    @staticmethod
+    def parse_yaml_config(config_file_path, input_value):
+        """
+        Read a configuration file for organizing a runfolder 
+        or analyzed project prior to delivery. 
+        This function will do string substitutions based on the input, 
+        keys in the configuration file and results from resolved 
+        regular expressions (based on patterns from the configuration file). 
+
+        :param config_file_path: Full path to a 
+        configuration file in yaml-format.
+        :param input_value: A runfolder name or a 
+        project name (for analysed projects).
+        :return: A list with one element per link/copy operation to be 
+        performed during organisation.
+         Each element consist of a tuple with 3 values 
+         ("path/to/source/file", 
+         "path/to/destination/file", 
+         "options as dictionary").
+        """
+
+        config = OrganiseService.load_yaml_config(config_file_path)
+
+        config["variables"]["inputkey"] = input_value
         variables_dict = config["variables"]
 
         config_as_list = []
 
         for key in variables_dict.keys():
-            variables_dict[key] = variables_dict[key].format_map(Default(variables_dict))
+            #Perform string substitutions on variable
+            #  values based on variable keys.
+            variables_dict[key] = OrganiseService.sub_values_with_dict(
+                variables_dict[key], 
+                variables_dict)
 
-        for element in config["files_to_organise"]:
-            element["source"] = element["source"].format_map(Default(variables_dict))
-            element["destination"] = element["destination"].format_map(Default(variables_dict))
+        for file_element in config["files_to_organise"]:
+            # for each source-destination pair, 
+            # under "files_to_organise", given in the configuration file
+            config_as_list = config_as_list + OrganiseService.process_file_to_organise(
+                file_element, 
+                variables_dict)
 
-            if "filter" in element["options"].keys(): 
-                element["options"]["filter"] = element["options"]["filter"].format_map(Default(variables_dict))
-                source_list = OrganiseService.resolve_config_regexp(element["options"]["filter"])
-                for source_file in source_list:
-                    source = ''.join([element["source"].strip('*'),source_file["source_file"]])
-                    destination_file = element["destination"].format_map(Default(source_file))
-                    destination = ''.join([destination_file, source_file["source_file"].split("/")[-1]])
-                    
-                    config_as_list.append((source,destination,element["options"]))
-
-            else:
-                config_as_list.append((element["source"],element["destination"],element["options"]))
-
-        return(config_as_list)
-
-    def resolve_config_regexp(regexp_pattern):
+        return config_as_list
+        
+    @staticmethod
+    def process_file_to_organise(file_element, variables_dict):
         """
-        This function will parse through a list of files/paths and select all files/paths matching
+        Function to handle a separate element of "files_to_organise"
+          from the cofiguration file.
+        Each element has one source, one destination and options available. 
+        This function will resolve the source and destination into 
+        several source files and destination files if applicable. 
+        Unknowns in the source and destination path will be 
+        resolved by substitutions or by calling resolve_config_regexp().
+        :param file_element: A dictionary with keys: source, destination, options 
+        corresponding to one element of the 
+        "files_to_organise" section in the configuration file.
+        :param variables_dict: A dictionary corresponding to the 
+        section "variables" from the configuration file.
+        :return: A list with all selected files under source. 
+        Each element is a tuple
+          (/source/path/, /destination/path/, {"options": "as dict"}) 
+        """
+        file_element["source"] = OrganiseService.sub_values_with_dict(
+            file_element["source"], 
+            variables_dict)
+        file_element["destination"] = OrganiseService.sub_values_with_dict(
+            file_element["destination"],
+            variables_dict)
+        file_to_organise_list = []
+
+        #Get at list from the filesystem with all files under "source"
+        list_of_mock_files = OrganiseService.get_mock_file_list()
+
+        #Get the filter pattern given in the configuration file and
+        #  substitute available values. 
+        #If filter isn't defined in the configuration file, use an 
+        # empty string as pattern to return all files under source.
+        filter_pattern = OrganiseService.sub_values_with_dict(
+            file_element["options"].get("filter", ""), 
+            variables_dict)
+            
+        source_list = OrganiseService.resolve_config_regexp(
+            filter_pattern, 
+            list_of_mock_files)
+        for source_file in source_list:
+            #substitute unknowns in destination path based on 
+            # varibales found in source file
+            destination_file = OrganiseService.sub_values_with_dict(
+                file_element["destination"], 
+                source_file)
+            file_to_organise_list.append(
+                (source_file["source_file"],
+                 destination_file,file_element["options"]))
+            
+        return file_to_organise_list
+
+    @staticmethod
+    def sub_values_with_dict(value, sub_dict):
+        """
+        Function to substitute values in a string based on keys from a dictionary. 
+        :param value: A string with values to substitute,
+          e.g. "/path/to/{sub}/file"
+        :param sub_dict: A dictionary with one or several keys 
+        that should be substituted, e.g {"sub": "dir1"}.
+        :return: Input string with one or more parts substituted,
+          e.g. "/path/to/dir1/file".
+        If one or several keys can't be found in the dictionary the key 
+        it self will be used as default value.
+        e.g. "/path/to/{sub1}/{sub2}/file" and {"sub1": "dir1"} as 
+        input will return "/path/to/dir1/{sub2}/file".
+        """
+        
+        return value.format_map(Default(sub_dict))
+
+    @staticmethod
+    def resolve_config_regexp(regexp_pattern, list_of_source_files):
+        """
+        This function will parse through a list of files/paths and 
+        select all files/paths matching
         the given regexp pattern.
 
-        :param regexp_pattern: A regular expression as specified in the configuration option "filter".
-        :return: A list where each element is a dictionary containing keys specified by the input regexp pattern.
-        The number of elements in the list is decided by the number of matches the re.search() returns. To each
-        list element, i.e. to each dictionary, the actual match (the source file) is also added.  
+        :param regexp_pattern: A regular expression as specified in 
+        the configuration option "filter".
+        :param list_of_source_files: A list of all files under the 
+        source specified in the configuration file,
+         as listed from the filesystem.
+        :return: A list where each element is a dictionary containing 
+        keys specified by the input regexp pattern.
+        The number of elements in the list is decided by the number of 
+        matches the re.search() returns. To each
+        list element, i.e. to each dictionary, the actual match 
+        (the source file) is also added. If there is no
+        regexp pattern given as input the returned dictionary will 
+        only have on key and value.
+        {"source_file": "/path/to/source/file"}
         """
-        list_of_mock_files = OrganiseService.get_mock_file_list()
         source_file_list = []
-        for file in list_of_mock_files:
+        for file in list_of_source_files:
             search_re = re.search(regexp_pattern, file)
+            
             if search_re == None:
-                pass
+                #If there is no pattern to filter files on, we want 
+                # all files available in source.
+                #No variables will be resolved and only the path to 
+                # the source file is returned.
+                source_file_dict = {}
+                source_file_dict["source_file"] = file
+                source_file_list.append(source_file_dict)
             else:
+                #If there is pattern submitted we save resolved 
+                # variables in a dictionary
                 source_file = search_re.group()
                 source_file_dict = search_re.groupdict()
-                source_file_dict["source_file"] = source_file 
+                source_file_dict["source_file"] = file
                 source_file_list.append(source_file_dict)
   
-        return(source_file_list)
+        return source_file_list
 
     def get_mock_file_list():
         """
-        Mock function for getting a list with all files found in on "source" specified in the config.
-        Only for testing purpose. Remove this function when code is getting intergated.
+        Mock function for getting a list with all files found in on
+          "source" specified in the config.
+        Only for testing purpose. Remove this function when code 
+        is getting intergated.
         """
-        file_list = ["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz",
+        file_list_runfolder = ["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz",
                      "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R2_001.fastq.gz",
                      "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14597/AB-1234-14597_S35_L001_R1_001.fastq.gz",
                      "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14597/AB-1234-14597_S35_L001_R2_001.fastq.gz",
                      "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/CD-5678/Sample_CD-5678-1/CD-5678-1_S89_L001_R1_001.fastq.gz",
                      "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/CD-5678/Sample_CD-5678-1/CD-5678-1_S89_L001_R1_001.fastq.gz",
                      "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/AB-1234/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html",
-                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/CD-5678/200624_A00834_0183_BHMTFYDRXX_CD-5678_multiqc_report.html"] 
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/CD-5678/200624_A00834_0183_BHMTFYDRXX_CD-5678_multiqc_report.html"]
 
-        return file_list
+        return file_list_runfolder
 
 
 class Default(dict):

--- a/delivery/services/organise_service.py
+++ b/delivery/services/organise_service.py
@@ -2,16 +2,19 @@
 import logging
 import os
 import time
+import sys
+import yaml
+import json
+import re
 
-from delivery.exceptions import ProjectAlreadyOrganisedException
+#from delivery.exceptions import ProjectAlreadyOrganisedException
 
-from delivery.models.project import RunfolderProject
-from delivery.models.runfolder import Runfolder, RunfolderFile
-from delivery.models.sample import Sample, SampleFile
-from delivery.services.file_system_service import FileSystemService
+#from delivery.models.project import RunfolderProject
+#from delivery.models.runfolder import Runfolder, RunfolderFile
+#from delivery.models.sample import Sample, SampleFile
+#from delivery.services.file_system_service import FileSystemService
 
 log = logging.getLogger(__name__)
-
 
 class OrganiseService(object):
     """
@@ -21,7 +24,8 @@ class OrganiseService(object):
     This service handles that in a synchronous way.
     """
 
-    def __init__(self, runfolder_service, file_system_service=FileSystemService()):
+    #def __init__(self, runfolder_service, file_system_service=FileSystemService()):
+    def __init__(self, runfolder_service, file_system_service=None):
         """
         Instantiate a new OrganiseService
         :param runfolder_service: an instance of a RunfolderService
@@ -207,3 +211,107 @@ class OrganiseService(object):
             read_no=sample_file.read_no,
             is_index=sample_file.is_index,
             checksum=sample_file.checksum)
+
+    def parse_yaml_config(config_file_path, input_key, input_value):
+        """
+        Read a configuration file for organizing a runfolder or analyzed project prior to delivery. 
+        This function will do string substitutions based on the input, keys in the configuration file
+         and results from resolved regular expressions (based on patterns from the configuration file). 
+
+        :param config_file_path: Full path to a configuration file in yaml-format.
+        :param input_key: projectid or runfolder_name
+        :param input_value: A runfolder name or a project name (for analysed projects).
+        :return: A list with one element per link/copy operation to be performed during organisation.
+         Each element consist of a tuple with 3 values ("path/to/source/file", "path/to/destination/file", "options as dictionary").
+        """
+
+        with open(config_file_path) as f:
+            config = yaml.load(f, Loader=yaml.SafeLoader)
+
+        input_dict = {}
+        input_dict[input_key] = input_value
+        input_dict.update(config["variables"]) #The input variable must be the first occuring key.
+        config["variables"] = input_dict
+        variables_dict = config["variables"]
+
+        config_as_list = []
+
+        for key in variables_dict.keys():
+            variables_dict[key] = variables_dict[key].format_map(Default(variables_dict))
+
+        for element in config["files_to_organise"]:
+            element["source"] = element["source"].format_map(Default(variables_dict))
+            element["destination"] = element["destination"].format_map(Default(variables_dict))
+
+            if "filter" in element["options"].keys(): 
+                element["options"]["filter"] = element["options"]["filter"].format_map(Default(variables_dict))
+                source_list = OrganiseService.resolve_config_regexp(element["options"]["filter"])
+                for source_file in source_list:
+                    source = ''.join([element["source"].strip('*'),source_file["source_file"]])
+                    destination_file = element["destination"].format_map(Default(source_file))
+                    destination = ''.join([destination_file, source_file["source_file"].split("/")[-1]])
+                    
+                    config_as_list.append((source,destination,element["options"]))
+
+            else:
+                config_as_list.append((element["source"],element["destination"],element["options"]))
+
+        return(config_as_list)
+
+    def resolve_config_regexp(regexp_pattern):
+        """
+        This function will parse through a list of files/paths and select all files/paths matching
+        the given regexp pattern.
+
+        :param regexp_pattern: A regular expression as specified in the configuration option "filter".
+        :return: A list where each element is a dictionary containing keys specified by the input regexp pattern.
+        The number of elements in the list is decided by the number of matches the re.search() returns. To each
+        list element, i.e. to each dictionary, the actual match (the source file) is also added.  
+        """
+        list_of_mock_files = OrganiseService.get_mock_file_list()
+        source_file_list = []
+        for file in list_of_mock_files:
+            search_re = re.search(regexp_pattern, file)
+            if search_re == None:
+                pass
+            else:
+                source_file = search_re.group()
+                source_file_dict = search_re.groupdict()
+                source_file_dict["source_file"] = source_file 
+                source_file_list.append(source_file_dict)
+  
+        return(source_file_list)
+
+    def get_mock_file_list():
+        """
+        Mock function for getting a list with all files found in on "source" specified in the config.
+        Only for testing purpose. Remove this function when code is getting intergated.
+        """
+        file_list = ["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R2_001.fastq.gz",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14597/AB-1234-14597_S35_L001_R1_001.fastq.gz",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14597/AB-1234-14597_S35_L001_R2_001.fastq.gz",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/CD-5678/Sample_CD-5678-1/CD-5678-1_S89_L001_R1_001.fastq.gz",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/CD-5678/Sample_CD-5678-1/CD-5678-1_S89_L001_R1_001.fastq.gz",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/AB-1234/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html",
+                     "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/CD-5678/200624_A00834_0183_BHMTFYDRXX_CD-5678_multiqc_report.html"] 
+
+        return file_list
+
+
+class Default(dict):
+    def __missing__(self, key):
+        return f"{{{key}}}"
+
+
+
+if __name__ == "__main__":
+    config_file_path = sys.argv[1]
+    input_key = sys.argv[2]
+    input_value = sys.argv[3]
+
+    if not os.path.exists(config_file_path):
+        raise Exception("Config file does not exist.")
+
+    config_as_list = OrganiseService.parse_yaml_config(config_file_path=config_file_path , input_key=input_key, input_value=input_value)
+    

--- a/tests/unit_tests/services/test_organise_service.py
+++ b/tests/unit_tests/services/test_organise_service.py
@@ -27,7 +27,8 @@ class TestOrganiseService(unittest.TestCase):
         self.file_system_service = mock.MagicMock(spec=FileSystemService)
         self.runfolder_service = mock.MagicMock(spec=RunfolderService)
         self.project_repository = mock.MagicMock(spec=GeneralProjectRepository)
-        self.sample_repository = mock.MagicMock(spec=RunfolderProjectBasedSampleRepository)
+        self.sample_repository = mock.MagicMock(
+            spec=RunfolderProjectBasedSampleRepository)
         self.organise_service = OrganiseService(
             self.runfolder_service,
             file_system_service=self.file_system_service)
@@ -36,12 +37,19 @@ class TestOrganiseService(unittest.TestCase):
         self.runfolder_service.find_runfolder.return_value = self.runfolder
         self.runfolder_service.find_projects_on_runfolder.side_effect = [[self.project]]
         self.file_system_service.exists.return_value = False
-        with mock.patch.object(self.organise_service, "organise_project", autospec=True) as organise_project_mock:
+        with mock.patch.object(
+            self.organise_service, 
+            "organise_project", 
+            autospec=True) as organise_project_mock:
             runfolder_id = self.runfolder.name
             lanes = [1, 2, 3]
             projects = ["a", "b", "c"]
             force = False
-            self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
+            self.organise_service.organise_runfolder(
+                runfolder_id, 
+                lanes, 
+                projects, 
+                force)
             organise_project_mock.assert_called_once_with(
                 self.runfolder,
                 self.project,
@@ -79,7 +87,10 @@ class TestOrganiseService(unittest.TestCase):
     def test_organise_runfolder_already_organised(self):
         self.runfolder_service.find_runfolder.return_value = self.runfolder
         self.file_system_service.exists.return_value = True
-        with mock.patch.object(self.organise_service, "organise_project", autospec=True) as organise_project_mock:
+        with mock.patch.object(
+            self.organise_service, 
+            "organise_project", 
+            autospec=True) as organise_project_mock:
             expected_organised_project = "this-is-an-organised-project"
             organise_project_mock.return_value = expected_organised_project
             self.runfolder_service.find_projects_on_runfolder.side_effect = [[self.project], [self.project]]
@@ -106,7 +117,11 @@ class TestOrganiseService(unittest.TestCase):
             self.file_system_service.dirname.side_effect = os.path.dirname
             lanes = [1, 2, 3]
             organised_projects_path = os.path.join(self.project.runfolder_path, "Projects")
-            self.organise_service.organise_project(self.runfolder, self.project, organised_projects_path, lanes)
+            self.organise_service.organise_project(
+                self.runfolder, 
+                self.project, 
+                organised_projects_path, 
+                lanes)
             organise_sample_mock.assert_has_calls([
                 mock.call(
                     sample,
@@ -116,8 +131,12 @@ class TestOrganiseService(unittest.TestCase):
             organise_project_file_mock.assert_has_calls([
                 mock.call(
                     project_file,
-                    os.path.join(organised_projects_path, self.project.name, self.project.runfolder_name),
-                    project_file_base=os.path.dirname(self.project.project_files[0].file_path)
+                    os.path.join(
+                        organised_projects_path, 
+                        self.project.name, 
+                        self.project.runfolder_name),
+                    project_file_base=os.path.dirname(
+                        self.project.project_files[0].file_path)
                 )
                 for project_file in self.project.project_files])
 
@@ -126,7 +145,10 @@ class TestOrganiseService(unittest.TestCase):
         self.file_system_service.relpath.side_effect = os.path.relpath
         self.file_system_service.dirname.side_effect = os.path.dirname
         for sample in self.project.samples:
-            organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [])
+            organised_sample = self.organise_service.organise_sample(
+                sample, 
+                self.organised_project_path, 
+                [])
             sample_file_dir = os.path.relpath(
                 os.path.dirname(
                     sample.sample_files[0].file_path),
@@ -134,19 +156,26 @@ class TestOrganiseService(unittest.TestCase):
             relative_path = os.path.join("..", "..", "..", "..", sample_file_dir)
             self.file_system_service.symlink.assert_has_calls([
                 mock.call(
-                    os.path.join(relative_path, os.path.basename(sample_file.file_path)),
+                    os.path.join(relative_path, os.path.basename(
+                        sample_file.file_path)),
                     sample_file.file_path) for sample_file in organised_sample.sample_files])
 
     def test_organise_sample_exclude_by_lane(self):
 
         # all sample lanes are excluded
         for sample in self.project.samples:
-            organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [0])
+            organised_sample = self.organise_service.organise_sample(
+                sample, 
+                self.organised_project_path, 
+                [0])
             self.assertListEqual([], organised_sample.sample_files)
 
         # a specific sample lane is excluded
         for sample in self.project.samples:
-            organised_sample = self.organise_service.organise_sample(sample, self.organised_project_path, [2, 3])
+            organised_sample = self.organise_service.organise_sample(
+                sample, 
+                self.organised_project_path, 
+                [2, 3])
             self.assertListEqual(
                 list(map(lambda x: x.file_name, filter(lambda f: f.lane_no in [2, 3], sample.sample_files))),
                 list(map(lambda x: x.file_name, organised_sample.sample_files)))
@@ -184,7 +213,13 @@ class TestOrganiseService(unittest.TestCase):
                             os.path.dirname(sample_file.file_path)),
                         os.path.basename(sample_file.file_path)),
                     expected_link_path)
-                for attr in ("file_name", "sample_name", "sample_index", "lane_no", "read_no", "is_index", "checksum"):
+                for attr in ("file_name", 
+                             "sample_name", 
+                             "sample_index", 
+                             "lane_no", 
+                             "read_no", 
+                             "is_index", 
+                             "checksum"):
                     self.assertEqual(
                         getattr(sample_file, attr),
                         getattr(organised_sample_file, attr))
@@ -198,7 +233,9 @@ class TestOrganiseService(unittest.TestCase):
                     project_file_base,
                     project_file),
                 file_checksum="checksum-for-{}".format(project_file))
-            for project_file in ("a-report-file", os.path.join("report-dir", "another-report-file"))]
+            for project_file in ("a-report-file", os.path.join(
+                "report-dir", 
+                "another-report-file"))]
         self.file_system_service.relpath.side_effect = os.path.relpath
         self.file_system_service.dirname.side_effect = os.path.dirname
         for project_file in project_files:
@@ -218,70 +255,163 @@ class TestOrganiseService(unittest.TestCase):
                 os.path.join("..", "..", "..", "foo", "report-dir", "another-report-file"),
                 os.path.join(organised_project_path, "report-dir", "another-report-file"))])
 
-    def test_parse_yaml_config_project(self):
-        config_file_path = "config/organise_config/organise_project.yml"
-        input_key = "projectid"
-        input_value = "ABC-123"
-        
-        self.assertEqual(OrganiseService.parse_yaml_config(config_file_path,input_key,input_value),
-                        [("/proj/ngi2016001/nobackup/NGI/ANALYSIS/ABC-123/results",
-                          "/proj/ngi2016001/nobackup/NGI/DELIVERY/ABC-123/results",
-                          {"required": True,"link_type": "softlink"}),
-                         ("/proj/ngi2016001/nobackup/NGI/DELIVERY/softlinks/DELIVERY.README.RNASEQ.md",
-                          "/proj/ngi2016001/nobackup/NGI/DELIVERY/ABC-123/DELIVERY.README.RNASEQ.md",
-                          {"required": True,"link_type": "softlink"}),
-                          ("/proj/ngi2016001/incoming/*/Projects/ABC-123",
-                          "/proj/ngi2016001/nobackup/NGI/DELIVERY/ABC-123/fastq/",
-                          {"required": True,"link_type": "softlink"})])
-
-    def test_parse_yaml_config_runfolder_empty(self):
+    def test_parse_yaml_config_empty_source(self):
         '''
-        If the input (i.e. the list of files) is empty the output will be empty in this case since
-        we have a "filter" option for all files_to_organise in the given configuration file.
+        If the input (i.e. the list of files) is empty 
+        the output will be empty in this case since
+        we have a "filter" option for all files_to_organise in 
+        the given configuration file.
         '''
         config_file_path = "config/organise_config/organise_runfolder.yml"
-        input_key = "runfolder_name"
         input_value = "200624_A00834_0183_BHMTFYDRXX"
 
         OrganiseService.get_mock_file_list = mock.MagicMock(return_value=[])
 
-        self.assertEqual(OrganiseService.parse_yaml_config(config_file_path,input_key,input_value),[])
-
-    def test_parse_yaml_config_runfolder_reports(self):
-        config_file_path = "config/organise_config/organise_runfolder.yml"
-        input_key = "runfolder_name"
-        input_value = "200624_A00834_0183_BHMTFYDRXX"
-
-        OrganiseService.get_mock_file_list = mock.MagicMock(return_value=["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/AB-1234/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html"])
-
-        expected_output = [("/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/project/AB-1234/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html",
-        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/AB-1234/200624_A00834_0183_BHMTFYDRXX/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html", 
-        {"required": True,
-        "link_type": "softlink",
-        "filter": "(?P<projectid>[\w-]+)/200624_A00834_0183_BHMTFYDRXX_(?P=projectid)_multiqc_report[\w.-]+"})]
-
-        self.assertEqual(OrganiseService.parse_yaml_config(config_file_path,input_key,input_value),expected_output)
+        self.assertEqual(OrganiseService.parse_yaml_config(
+            config_file_path, 
+            input_value), 
+            [])
 
     def test_parse_yaml_config_runfolder_fastq(self):
-        config_file_path = "config/organise_config/organise_runfolder.yml"
-        input_key = "runfolder_name"
+        config_file_path = "/path/to/config.yaml"
         input_value = "200624_A00834_0183_BHMTFYDRXX"
 
-        OrganiseService.get_mock_file_list = mock.MagicMock(return_value=["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz"])
+        OrganiseService.load_yaml_config = mock.MagicMock(
+            return_value={
+            "variables": 
+            {
+                "inputkey": "runfolder_name",  
+                "runfolderpath": "/proj/ngi2016001/incoming",
+                "runfolder": "{runfolderpath}/{inputkey}",
+                "organised": "{runfolder}/Projects",
+            },
+            "files_to_organise":
+                [{
+                "source": "{runfolder}/Unaligned/*",  
+                "destination": "{organised}/{projectid}/{inputkey}/Sample_{samplename}/",
+                "options":
+                    {
+                        "required": True,
+                        "link_type": "softlink",
+                        "filter": "(?P<projectid>[\\w-]+)/Sample_(?P<samplename>[\\w-]+)/(?P=samplename)_S(?P<samplenumber>\\d+)_L(?P<lanes>\\d+)_R(?P<read>\\d)_001.fastq.gz"
+                    }
+                }]
+            })
+
+        OrganiseService.get_mock_file_list = mock.MagicMock(
+            return_value=[
+                "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz",
+                 "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14597/AB-1234-14597_S35_L001_R1_001.fastq.gz",
+                 "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/CD-5678/Sample_CD-5678-1/CD-5678-1_S89_L001_R1_001.fastq.gz"
+                 ]
+            )
 
         expected_output = [("/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz",
-        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/AB-1234/200624_A00834_0183_BHMTFYDRXX/Sample_AB-1234-14092/AB-1234-14092_S35_L001_R1_001.fastq.gz", 
+        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/AB-1234/200624_A00834_0183_BHMTFYDRXX/Sample_AB-1234-14092/", 
         {"required": True,
         "link_type": "softlink",
-        "filter": "(?P<projectid>[\w-]+)/Sample_(?P<samplename>[\w-]+)/(?P=samplename)_S(?P<samplenumber>\d+)_L(?P<lanes>\d+)_R(?P<read>\d)_001.fastq.gz"})]
+        "filter": "(?P<projectid>[\\w-]+)/Sample_(?P<samplename>[\\w-]+)/(?P=samplename)_S(?P<samplenumber>\\d+)_L(?P<lanes>\\d+)_R(?P<read>\\d)_001.fastq.gz"}),
+        ("/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14597/AB-1234-14597_S35_L001_R1_001.fastq.gz",
+        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/AB-1234/200624_A00834_0183_BHMTFYDRXX/Sample_AB-1234-14597/", 
+        {"required": True,
+        "link_type": "softlink",
+        "filter": "(?P<projectid>[\\w-]+)/Sample_(?P<samplename>[\\w-]+)/(?P=samplename)_S(?P<samplenumber>\\d+)_L(?P<lanes>\\d+)_R(?P<read>\\d)_001.fastq.gz"}),
+        ("/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/CD-5678/Sample_CD-5678-1/CD-5678-1_S89_L001_R1_001.fastq.gz",
+        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/CD-5678/200624_A00834_0183_BHMTFYDRXX/Sample_CD-5678-1/", 
+        {"required": True,
+        "link_type": "softlink",
+        "filter": "(?P<projectid>[\\w-]+)/Sample_(?P<samplename>[\\w-]+)/(?P=samplename)_S(?P<samplenumber>\\d+)_L(?P<lanes>\\d+)_R(?P<read>\\d)_001.fastq.gz"})]
 
-        self.assertEqual(OrganiseService.parse_yaml_config(config_file_path,input_key,input_value),expected_output)
+        self.assertEqual(OrganiseService.parse_yaml_config(
+            config_file_path,
+            input_value),
+            expected_output)
 
-    def test_parse_yaml_config_runfolder_no_filter_match(self):
-        config_file_path = "config/organise_config/organise_runfolder.yml"
-        input_key = "runfolder_name"
+    def test_parse_yaml_config_runfolder_reports(self):
+        config_file_path = "/path/to/config.yaml"
         input_value = "200624_A00834_0183_BHMTFYDRXX"
 
-        OrganiseService.get_mock_file_list = mock.MagicMock(return_value=["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Unaligned/AB-1234/Sample_AB-1234-14092/AB-1234-14092.txt"])
+        OrganiseService.load_yaml_config = mock.MagicMock(
+            return_value={
+            "variables": 
+            {
+                "inputkey": "runfolder_name",  
+                "runfolderpath": "/proj/ngi2016001/incoming",
+                "runfolder": "{runfolderpath}/{inputkey}",
+                "organised": "{runfolder}/Projects",
+            },
+            "files_to_organise":
+                [{
+                "source": "{runfolder}/seqreports/projects/*",
+                "destination": "{organised}/{projectid}/{inputkey}/",
+                "options":
+                    {
+                        "required": True,
+                        "link_type": "softlink",
+                        "filter": "(?P<projectid>[\\w-]+)/{inputkey}_(?P=projectid)_multiqc_report[\\w.-]+"
+                    }
+                }]
+            })
 
-        self.assertEqual(OrganiseService.parse_yaml_config(config_file_path,input_key,input_value),[])
+        OrganiseService.get_mock_file_list = mock.MagicMock(
+            return_value=["/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/projects/AB-1234/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html",
+                          "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/projects/CD-5678/200624_A00834_0183_BHMTFYDRXX_CD-5678_multiqc_report.html"]
+                          )
+
+        expected_output = [("/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/projects/AB-1234/200624_A00834_0183_BHMTFYDRXX_AB-1234_multiqc_report.html",
+        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/AB-1234/200624_A00834_0183_BHMTFYDRXX/", 
+        {"required": True,
+        "link_type": "softlink",
+        "filter": "(?P<projectid>[\\w-]+)/{inputkey}_(?P=projectid)_multiqc_report[\\w.-]+"}),
+        ("/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/seqreports/projects/CD-5678/200624_A00834_0183_BHMTFYDRXX_CD-5678_multiqc_report.html",
+        "/proj/ngi2016001/incoming/200624_A00834_0183_BHMTFYDRXX/Projects/CD-5678/200624_A00834_0183_BHMTFYDRXX/", 
+        {"required": True,
+        "link_type": "softlink",
+        "filter": "(?P<projectid>[\\w-]+)/{inputkey}_(?P=projectid)_multiqc_report[\\w.-]+"})]
+
+        self.assertEqual(OrganiseService.parse_yaml_config(
+            config_file_path,
+            input_value),
+            expected_output)
+
+    def test_parse_yaml_config_no_filter(self):
+        config_file_path = "/path/to/config.yaml"
+        input_value = "AB-1234"
+
+        OrganiseService.load_yaml_config = mock.MagicMock(
+            return_value={
+            "variables":
+            {
+            "inputkey": "projectid",
+            "rootpath": "/proj/ngi2016001/nobackup/NGI",
+            "runfolderpath": "/proj/ngi2016001/incoming",
+            "analysispath": "{rootpath}/ANALYSIS/{inputkey}",
+            "deliverypath": "{rootpath}/DELIVERY/{inputkey}"
+            },
+            "files_to_organise":
+                [{
+                "source": "{analysispath}/results",
+                "destination": "{deliverypath}/results",
+                "options":
+                    {
+                        "required": True,
+                        "link_type": "softlink"
+                    }
+                }]
+            })
+
+        OrganiseService.get_mock_file_list = mock.MagicMock(
+            return_value=["/proj/ngi2016001/nobackup/NGI/ANALYSIS/AB-1234/results"]
+                          )
+        expected_output = [("/proj/ngi2016001/nobackup/NGI/ANALYSIS/AB-1234/results",
+                            "/proj/ngi2016001/nobackup/NGI/DELIVERY/AB-1234/results",
+                            {
+                                "required": True,
+                                "link_type": "softlink"
+                            }
+                            )]
+
+        self.assertEqual(OrganiseService.parse_yaml_config(
+            config_file_path, 
+            input_value), 
+            expected_output)


### PR DESCRIPTION
**What problems does this PR solve?**
Added a function that can open, read and parse a yaml.config file for organising files prior to delivery. Can be applied on an anlysed project or a single runfolder. The code will resolve regular expressions, using the pattern given in the configuration file, to find source files to link to a destination file. Based on the input and the resolved regular expressions string substitution will be performed to update/resolve paths given in the configuration file.  

**How has the changes been tested?**
Only unittests.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
