### PR TITLE
Dataops 489 record dds version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .coverage
 *.db
 *.log
+venv/*

--- a/delivery/handlers/delivery_handlers.py
+++ b/delivery/handlers/delivery_handlers.py
@@ -64,8 +64,11 @@ class DeliverByStageIdHandler(ArteriaDeliveryBaseHandler):
                 self.reverse_url("delivery_status", delivery_id))
 
         self.set_status(ACCEPTED)
+
+        dds_version = dds_project.get_dds_version()
         self.write_json({'delivery_order_id': delivery_id,
-                         'delivery_order_link': status_end_point})
+                         'delivery_order_link': status_end_point,
+                         'dds_version': dds_version})
 
 
 class DeliveryStatusHandler(ArteriaDeliveryBaseHandler):

--- a/delivery/models/project.py
+++ b/delivery/models/project.py
@@ -165,6 +165,19 @@ class DDSProject:
                 " Check token expiry date (`dds auth info`).")
             raise
 
+    @gen.coroutine
+    def get_dds_version(self):
+        """
+        Get the DDS version been used
+        """
+
+        cmd = ['dds', '--version']
+        result = yield self._run(cmd) # should return "Data Delivery System, version 2.6.1"
+        version_stdout = ''.join(result)
+        version = (version_stdout.split("version")[-1]).strip()
+        return version
+
+
     @classmethod
     @gen.coroutine
     def new(

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -4,7 +4,8 @@ import mock
 import random
 import logging
 
-from subprocess import PIPE
+
+from subprocess import PIPE, run as subprocess_run
 
 from tornado.testing import *
 from tornado.web import Application
@@ -125,6 +126,8 @@ class BaseIntegration(AsyncHTTPTestCase):
                         new_cmd += ['&&', 'test', '-e', auth_token]
                         new_cmd = " ".join(new_cmd)
                         shell = True
+                    elif '--version' in cmd:
+                        new_cmd += ['&&', 'echo',  f"2.6.1"]
                 else:
                     new_cmd = cmd
 

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -108,6 +108,9 @@ class TestIntegrationDDS(BaseIntegration):
 
                 status_response = yield self.http_client.fetch(delivery_link)
                 self.assertEqual(json.loads(status_response.body)["status"], DeliveryStatus.delivery_skipped.name)
+                
+                dds_version = delivery_resp_as_json['dds_version']
+                self.assertEqual(dds_version, '2.6.1')
 
     @gen_test
     def test_can_stage_and_deliver_clean_flowcells(self):

--- a/tests/unit_tests/services/test_dds.py
+++ b/tests/unit_tests/services/test_dds.py
@@ -410,3 +410,35 @@ project"""
 
             ngi_project_name = yield dds_project.get_ngi_project_name()
             self.assertEqual(ngi_project_name, "AB-1234")
+
+    @gen_test
+    def test_get_dds_version(self):
+        project_id = 'snpseq00001'
+        mocked_version = "2.6.1"
+
+        with patch(
+                'delivery.models.project.DDSProject._run',
+                new_callable=AsyncMock,
+                return_value=mocked_version,
+                ):
+                
+                dds_project = DDSProject(
+                        dds_service=self.dds_service,
+                        auth_token=self.token_file.name,
+                        dds_project_id=project_id,
+                        )
+
+                dds_version = yield dds_project.get_dds_version()
+                self.assertEqual(dds_version, mocked_version)
+        
+
+        yield dds_project.get_dds_version()
+        self.mock_dds_runner.run.assert_has_calls([
+                call([
+                        'dds',
+                        '--version', 
+                        ])
+                ])
+
+                        
+


### PR DESCRIPTION
**What problems does this PR solve?**
The DDS service now returns the DDS version used. This information is required by those who use the DDS service here

**How has the changes been tested?**
Test that DDS service is among the fields returned

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be initiated.

  - [ ] This PR contains code that could remove data
