### PR TITLE
Added support to read bclconvert samplseheets v2

### DIFF
--- a/delivery/handlers/organise_handlers.py
+++ b/delivery/handlers/organise_handlers.py
@@ -56,6 +56,7 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
         force = request_data.get("force", False)
         lanes = request_data.get("lanes", [])
         projects = request_data.get("projects", [])
+        demultiplexer = request_data.get("demultiplexer", "bcl2fastq")
 
         if any([force, lanes, projects]):
             log.info(
@@ -63,7 +64,9 @@ class OrganiseRunfolderHandler(BaseOrganiseHandler):
                     [force, lanes, projects]))
 
         try:
-            organised_runfolder = self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
+            organised_runfolder = self.organise_service.organise_runfolder(
+                runfolder_id, lanes, projects, force, demultiplexer
+            )
 
             self.set_status(OK)
             self.write_json({

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -16,6 +16,8 @@ SAMPLESHEET_DATA_HEADERS_DICT = {
     'bcl2fastq': '[Data]',
     'bclconvert': '[BCLConvert_Data]'
 }
+
+
 class FileSystemBasedRunfolderRepository(object):
     """
     Uses the file system as a source of truth for information about what runfolders are available.

--- a/delivery/repositories/runfolder_repository.py
+++ b/delivery/repositories/runfolder_repository.py
@@ -148,7 +148,7 @@ class FileSystemBasedRunfolderRepository(object):
 
     def get_samplesheet(self, runfolder, samplesheet_data_header):
         return self.metadata_service.extract_samplesheet_data(
-            self.samplesheet_file(runfolder, samplesheet_data_header)
+            self.samplesheet_file(runfolder), samplesheet_data_header
         )
 
 

--- a/delivery/services/metadata_service.py
+++ b/delivery/services/metadata_service.py
@@ -13,14 +13,13 @@ class MetadataService(object):
     """
 
     @staticmethod
-    def extract_samplesheet_data(samplesheet_file):
-
+    def extract_samplesheet_data(samplesheet_file, samplesheet_data_header):
         def _extract_samplesheet_data_section(filehandle):
             return list(csv.DictReader(filehandle))
 
         try:
             with open(samplesheet_file, "r") as fh:
-                while not next(fh).startswith("[Data]"):
+                while not next(fh).startswith(samplesheet_data_header):
                     pass
                 return _extract_samplesheet_data_section(fh)
         except IOError as e:
@@ -45,10 +44,10 @@ class MetadataService(object):
                 fh.write("{}  {}\n".format(checksum, file_path))
 
     @staticmethod
-    def write_samplesheet_file(samplesheet_file, samplesheet_data):
+    def write_samplesheet_file(samplesheet_file, samplesheet_data, samplesheet_data_header):
         header = samplesheet_data[0].keys()
         with open(samplesheet_file, "w") as fh:
-            fh.write("[Data]\n")
+            fh.write(f"{samplesheet_data_header}\n")
             writer = csv.DictWriter(fh, fieldnames=header)
             writer.writeheader()
             writer.writerows(samplesheet_data)

--- a/delivery/services/runfolder_service.py
+++ b/delivery/services/runfolder_service.py
@@ -64,18 +64,19 @@ class RunfolderService(object):
         """
         return self.runfolder_repo.dump_project_checksums(project)
 
-    def dump_project_samplesheet(self, runfolder, project):
+    def dump_project_samplesheet(self, runfolder, project, demultiplexer):
         """
         Calls the `FileSystemBasedUnorganisedRunfolderRepository` instance associated with this service to write a
         samplesheet only including the supplied project.
 
         :param runfolder: an instance of Runfolder
         :param project: an instance of Project
+        :param demultiplexer: the demultiplexer used to generate the data (e.g. bcl2fastq, bclconvert)
         :return: the path to the created samplesheet file
         :raises NotImplementedError: if the runfolder repo instance is not a
         `FileSystemBasedUnorganisedRunfolderRepository`
         """
-        return self.runfolder_repo.dump_project_samplesheet(runfolder, project)
+        return self.runfolder_repo.dump_project_samplesheet(runfolder, project, demultiplexer)
 
     def get_project_report_files(self, runfolder, project):
         """

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -71,7 +71,7 @@ class BaseIntegration(AsyncHTTPTestCase):
         checksum_file = os.path.join(runfolder.path, "MD5", "checksums.md5")
         os.mkdir(os.path.dirname(checksum_file))
         MetadataService.write_checksum_file(checksum_file, runfolder.checksums)
-        samplesheet_file_from_runfolder(runfolder,demultiplexer)
+        samplesheet_file_from_runfolder(runfolder, demultiplexer)
 
     API_BASE = "/api/1.0"
 

--- a/tests/integration_tests/base.py
+++ b/tests/integration_tests/base.py
@@ -46,7 +46,7 @@ class BaseIntegration(AsyncHTTPTestCase):
         return checksum_file
 
     @staticmethod
-    def _create_runfolder_structure_on_disk(runfolder):
+    def _create_runfolder_structure_on_disk(runfolder, demultiplexer="bcl2fastq"):
 
         def _toggle():
             state = True
@@ -71,7 +71,7 @@ class BaseIntegration(AsyncHTTPTestCase):
         checksum_file = os.path.join(runfolder.path, "MD5", "checksums.md5")
         os.mkdir(os.path.dirname(checksum_file))
         MetadataService.write_checksum_file(checksum_file, runfolder.checksums)
-        samplesheet_file_from_runfolder(runfolder)
+        samplesheet_file_from_runfolder(runfolder,demultiplexer)
 
     API_BASE = "/api/1.0"
 

--- a/tests/integration_tests/test_integration_dds.py
+++ b/tests/integration_tests/test_integration_dds.py
@@ -231,14 +231,15 @@ class TestIntegrationDDS(BaseIntegration):
             unorganised_runfolder2 = self.create_unorganised_test_runfolders(tmpdir2)
             
             self._create_runfolder_structure_on_disk(unorganised_runfolder1)
-            self._create_runfolder_structure_on_disk(unorganised_runfolder2)
+            self._create_runfolder_structure_on_disk(unorganised_runfolder2, "bclconvert")
 
             url = "/".join([self.API_BASE, "organise", "runfolder", unorganised_runfolder1.name])
             response1 = yield self.http_client.fetch(self.get_url(url), method='POST', body='')
             self.assertEqual(response1.code, 200)
            
             url = "/".join([self.API_BASE, "organise", "runfolder", unorganised_runfolder2.name])
-            response2 = yield self.http_client.fetch(self.get_url(url), method='POST', body='')
+            payload = {'demultiplexer': 'bclconvert'}
+            response2 = yield self.http_client.fetch(self.get_url(url), method='POST', body=json.dumps(payload))
             self.assertEqual(response2.code, 200)
  
             # Then stage it

--- a/tests/unit_tests/services/test_metadata_service.py
+++ b/tests/unit_tests/services/test_metadata_service.py
@@ -21,7 +21,17 @@ class TestMetadataService(unittest.TestCase):
     def test_extract_samplesheet_data(self):
         runfolder = test_utils.unorganised_runfolder(self.rootdir)
         samplesheet_file, samplesheet_data = test_utils.samplesheet_file_from_runfolder(runfolder)
-        self.assertListEqual(samplesheet_data, self.metadata_service.extract_samplesheet_data(samplesheet_file))
+        self.assertListEqual(samplesheet_data, self.metadata_service.extract_samplesheet_data(
+            samplesheet_file, '[Data]'
+        ))
+
+    def test_extract_bclconvert_samplesheet_data(self):
+        runfolder = test_utils.unorganised_runfolder(self.rootdir)
+        samplesheet_file, samplesheet_data = test_utils.samplesheet_file_from_runfolder(runfolder, "bclconvert")
+
+        self.assertListEqual(samplesheet_data, self.metadata_service.extract_samplesheet_data(
+            samplesheet_file, '[BCLConvert_Data]'
+        ))
 
     def test_hash_string(self):
         expected_results = (

--- a/tests/unit_tests/services/test_organise_service.py
+++ b/tests/unit_tests/services/test_organise_service.py
@@ -41,14 +41,16 @@ class TestOrganiseService(unittest.TestCase):
             lanes = [1, 2, 3]
             projects = ["a", "b", "c"]
             force = False
-            self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force)
+            demultiplexer = "bclconvert"
+            self.organise_service.organise_runfolder(runfolder_id, lanes, projects, force, demultiplexer)
             organise_project_mock.assert_called_once_with(
                 self.runfolder,
                 self.project,
                 os.path.dirname(
                     os.path.dirname(
                         self.organised_project_path)),
-                lanes)
+                lanes,
+                demultiplexer)
 
     def test_check_previously_organised_project(self):
         organised_project_base_path = os.path.dirname(self.organised_project_path)
@@ -84,15 +86,15 @@ class TestOrganiseService(unittest.TestCase):
             organise_project_mock.return_value = expected_organised_project
             self.runfolder_service.find_projects_on_runfolder.side_effect = [[self.project], [self.project]]
             runfolder_id = self.runfolder.name
-
+            demultiplexer = "bcl2fastq"
             # without force
             self.assertRaises(
                 ProjectAlreadyOrganisedException,
                 self.organise_service.organise_runfolder,
-                runfolder_id, [], [], False)
+                runfolder_id, [], [], False, demultiplexer)
 
             # with force
-            organised_runfolder = self.organise_service.organise_runfolder(runfolder_id, [], [], True)
+            organised_runfolder = self.organise_service.organise_runfolder(runfolder_id, [], [], True, demultiplexer)
             self.assertEqual(self.runfolder.name, organised_runfolder.name)
             self.assertEqual(self.runfolder.path, organised_runfolder.path)
             self.assertEqual(self.runfolder.checksums, organised_runfolder.checksums)
@@ -106,7 +108,9 @@ class TestOrganiseService(unittest.TestCase):
             self.file_system_service.dirname.side_effect = os.path.dirname
             lanes = [1, 2, 3]
             organised_projects_path = os.path.join(self.project.runfolder_path, "Projects")
-            self.organise_service.organise_project(self.runfolder, self.project, organised_projects_path, lanes)
+            self.organise_service.organise_project(
+                self.runfolder, self.project, organised_projects_path, lanes, "bcl2fastq"
+            )
             organise_sample_mock.assert_has_calls([
                 mock.call(
                     sample,


### PR DESCRIPTION
**What problems does this PR solve?**
This version adds the support for bclcoverts samplesheets

**How has the changes been tested?**
This will be tested by running the delivery workflows fir bclconvert runs

**Reasons for careful code review**
Both bcl2fastq and bclconvert runs should be possible to deliver

  - [ ] This PR contains code that could remove data
